### PR TITLE
Fix homepage link

### DIFF
--- a/CKAN/Waterfall.netkan
+++ b/CKAN/Waterfall.netkan
@@ -8,7 +8,7 @@
     "author": "Chris Adderley (Nertea)",
     "license":      "CC-BY-NC-SA-4.0",
     "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/196309",
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/196309-*",
         "repository": "https://github.com/post-kerbin-mining-corporation/Waterfall"
     },
     "depends": [


### PR DESCRIPTION
This link doesn't load the thread, it goes to a forum listing:

- https://forum.kerbalspaceprogram.com/index.php?/topic/196309

IPS4 seems to need a dash and another character that isn't a slash:

- https://forum.kerbalspaceprogram.com/index.php?/topic/196309-*

Now users will be able to find the thread.

Found while reviewing KSP-CKAN/NetKAN#8274.

Tagging @ChrisAdderley to make GitHub send notifications.