### PR TITLE
minor engine glow update to new templates, new keroxide template

### DIFF
--- a/GameData/Waterfall/Templates/waterfall-alcolox-lower-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-alcolox-lower-1.cfg
@@ -3293,4 +3293,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.0299999993
+			rotationOffset = -90,0,0
+			scaleOffset = 1.20000005,1.20000005,1.20000005
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.980392158,0.97647059,0.968627453,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.823529422,0.549019635,0.784313738,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0.5 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-hydrolox-lower-3.cfg
+++ b/GameData/Waterfall/Templates/waterfall-hydrolox-lower-3.cfg
@@ -3615,4 +3615,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = fxTransformPlume
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.0299999993
+			rotationOffset = -90,0,0
+			scaleOffset = 1.20000005,1.20000005,1.20000005
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.760784328,0.290196091,0.0392156877,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.744364321,0.407843143,0.278431386,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 7.98889065
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 1.00666571
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1.3 0 0
+				key = 0.7 1.5 0 0
+				key = 1 0.7 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-hydrolox-lower-4.cfg
+++ b/GameData/Waterfall/Templates/waterfall-hydrolox-lower-4.cfg
@@ -4159,4 +4159,412 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.0299999993
+			rotationOffset = -90,0,0
+			scaleOffset = 1,1,1
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.589499354,0.0193797369,0,1
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.95073992,0.410500586,0.375369966,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		COLORMODIFIER
+		{
+			name = planeColourStart
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			colorName = _StartTint
+			rCurve
+			{
+				key = 0.2 0.1 0 0
+				key = 0.5 0.3 0 0
+				key = 1 0.8 0 0
+			}
+			gCurve
+			{
+				key = 0.5 0.3 0 0
+				key = 1 0.2 0 0
+			}
+			bCurve
+			{
+				key = 0.2 0.8 0 0
+				key = 0.5 0.5 0 0
+				key = 1 0.1 0 0
+			}
+			aCurve
+			{
+				key = 1 0 0 0
+			}
+		}
+		COLORMODIFIER
+		{
+			name = planeColourEnd
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			colorName = _EndTint
+			rCurve
+			{
+				key = 0.2 0.1 0 0
+				key = 0.5 0.3 0 0
+				key = 1 0.8 0 0
+			}
+			gCurve
+			{
+				key = 0.5 0.3 0 0
+				key = 1 0.2 0 0
+			}
+			bCurve
+			{
+				key = 0.2 0.8 0 0
+				key = 0.5 0.5 0 0
+				key = 1 0.1 0 0
+			}
+			aCurve
+			{
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1.3 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-hydrolox-upper-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-hydrolox-upper-1.cfg
@@ -1255,4 +1255,412 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.0299999993
+			rotationOffset = -90,0,0
+			scaleOffset = 1,1,1
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.589499354,0.0193797369,0,1
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.95073992,0.410500586,0.375369966,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		COLORMODIFIER
+		{
+			name = planeColourStart
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			colorName = _StartTint
+			rCurve
+			{
+				key = 0.2 0.1 0 0
+				key = 0.5 0.3 0 0
+				key = 1 0.8 0 0
+			}
+			gCurve
+			{
+				key = 0.5 0.3 0 0
+				key = 1 0.2 0 0
+			}
+			bCurve
+			{
+				key = 0.2 0.8 0 0
+				key = 0.5 0.5 0 0
+				key = 1 0.1 0 0
+			}
+			aCurve
+			{
+				key = 1 0 0 0
+			}
+		}
+		COLORMODIFIER
+		{
+			name = planeColourEnd
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			colorName = _EndTint
+			rCurve
+			{
+				key = 0.2 0.1 0 0
+				key = 0.5 0.3 0 0
+				key = 1 0.8 0 0
+			}
+			gCurve
+			{
+				key = 0.5 0.3 0 0
+				key = 1 0.2 0 0
+			}
+			bCurve
+			{
+				key = 0.2 0.8 0 0
+				key = 0.5 0.5 0 0
+				key = 1 0.1 0 0
+			}
+			aCurve
+			{
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1.3 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-hypergolic-HDA-UDMH-upper-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-hypergolic-HDA-UDMH-upper-1.cfg
@@ -1377,4 +1377,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0
+			rotationOffset = -90,0,0
+			scaleOffset = 1.10000002,1.10000002,1.10000002
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.725490212,0.427450985,0.352941185,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.913725495,0.23137255,0.23137255,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0.7 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-hypergolic-IRFNA-UDMH-upper-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-hypergolic-IRFNA-UDMH-upper-1.cfg
@@ -1148,4 +1148,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0
+			rotationOffset = -90,0,0
+			scaleOffset = 1.10000002,1.10000002,1.10000002
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.725490212,0.427450985,0.352941185,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.913725495,0.23137255,0.23137255,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0.7 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-hypergolic-UDMH-NTO-lower-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-hypergolic-UDMH-NTO-lower-1.cfg
@@ -4609,4 +4609,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.00999999978
+			rotationOffset = -90,0,0
+			scaleOffset = 0.899999976,0.899999976,0.899999976
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.639215708,0.572549045,0.4627451,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.921568632,0.698039234,0.576470613,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0.5 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-hypergolic-UDMH-NTO-upper-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-hypergolic-UDMH-NTO-upper-1.cfg
@@ -1642,4 +1642,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0
+			rotationOffset = -90,0,0
+			scaleOffset = 1.10000002,1.10000002,1.10000002
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.839215696,0.717647076,0.545098066,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.905882359,0.713725507,0.443137258,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0.7 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-hypergolic-aerozine50-lower-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-hypergolic-aerozine50-lower-1.cfg
@@ -4392,4 +4392,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.00999999978
+			rotationOffset = -90,0,0
+			scaleOffset = 0.899999976,0.899999976,0.899999976
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.639215708,0.572549045,0.4627451,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.921568632,0.698039234,0.576470613,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0.5 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-hypergolic-aerozine50-upper-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-hypergolic-aerozine50-upper-1.cfg
@@ -1377,4 +1377,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0
+			rotationOffset = -90,0,0
+			scaleOffset = 1.10000002,1.10000002,1.10000002
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.839215696,0.717647076,0.545098066,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.905882359,0.713725507,0.443137258,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0.7 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-hypergolic-white-upper-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-hypergolic-white-upper-1.cfg
@@ -1148,4 +1148,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0
+			rotationOffset = -90,0,0
+			scaleOffset = 1.10000002,1.10000002,1.10000002
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.839215696,0.717647076,0.545098066,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.905882359,0.713725507,0.443137258,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0.7 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-kerolox-lower-4.cfg
+++ b/GameData/Waterfall/Templates/waterfall-kerolox-lower-4.cfg
@@ -2593,4 +2593,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.00999999978
+			rotationOffset = -90,0,0
+			scaleOffset = 0.400000006,0.400000006,0.400000006
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.980392158,0.97647059,0.968627453,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.866666675,0.552941203,0.172549024,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1.09894991
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-kerolox-lower-5-film-cooled.cfg
+++ b/GameData/Waterfall/Templates/waterfall-kerolox-lower-5-film-cooled.cfg
@@ -2384,4 +2384,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.00999999978
+			rotationOffset = -90,0,0
+			scaleOffset = 0.400000006,0.400000006,0.400000006
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.980392158,0.97647059,0.968627453,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.866666675,0.552941203,0.172549024,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1.09894991
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-kerolox-lower-5.cfg
+++ b/GameData/Waterfall/Templates/waterfall-kerolox-lower-5.cfg
@@ -2236,4 +2236,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.00999999978
+			rotationOffset = -90,0,0
+			scaleOffset = 0.400000006,0.400000006,0.400000006
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.980392158,0.97647059,0.968627453,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.866666675,0.552941203,0.172549024,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1.09894991
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-kerolox-sustainer-2-film-cooled.cfg
+++ b/GameData/Waterfall/Templates/waterfall-kerolox-sustainer-2-film-cooled.cfg
@@ -1625,4 +1625,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.00999999978
+			rotationOffset = -90,0,0
+			scaleOffset = 0.400000006,0.400000006,0.400000006
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.980392158,0.97647059,0.968627453,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.866666675,0.552941203,0.172549024,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1.09894991
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-kerolox-sustainer-2.cfg
+++ b/GameData/Waterfall/Templates/waterfall-kerolox-sustainer-2.cfg
@@ -1477,4 +1477,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.00999999978
+			rotationOffset = -90,0,0
+			scaleOffset = 0.400000006,0.400000006,0.400000006
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.980392158,0.97647059,0.968627453,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.866666675,0.552941203,0.172549024,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1.09894991
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-kerolox-upper-3.cfg
+++ b/GameData/Waterfall/Templates/waterfall-kerolox-upper-3.cfg
@@ -1239,4 +1239,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0
+			rotationOffset = -90,0,0
+			scaleOffset = 0.5,0.5,0.5
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.980392158,0.97647059,0.968627453,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.866666675,0.552941203,0.172549024,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1.09894991
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-keroxide-lower-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-keroxide-lower-1.cfg
@@ -1,0 +1,2250 @@
+//sea level plume for engines using a combination of kerosene and hydrogen peroxide/High test peroxide. Eg Black Arrow
+// Credit Zorg
+EFFECTTEMPLATE
+{
+	templateName = waterfall-keroxide-lower-1
+	EFFECT
+	{
+		name = MainPlume
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,9
+			rotationOffset = -90,0,0
+			scaleOffset = 0.75,30,0.75
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.712372065,0.518633604,0.260682613,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.90196079,0.607843161,0.215686277,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = -2.32555199
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 1.01110971
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.292223364
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.394332737
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.15665865
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.783609867
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 10.1110954
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 37.3999443
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 6
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 9.70665264
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 1.49138653
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = Brightness
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.01 0.05 0 0
+				key = 1 0.2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = BrightnessAtm
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.4 0 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = EndFlame
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,15
+			rotationOffset = -90,0,0
+			scaleOffset = 1,20,1
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 2,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.674509823,0.537140846,0.413370967,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.725490212,0.501960814,0.200000003,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 1.21333146
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.657221198
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.642054558
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 3.2355504
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.66221333
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.79166079
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.454999298
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 7.0777669
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 17.1777534
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0.2022219
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0.100000001
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.758332133
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = BrightnessT
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.5 0 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = BrightnessATM
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.5 0 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aExpandLin
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandLinear
+			floatCurve
+			{
+				key = 0.4 6 0 0
+				key = 0.7 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = plume1
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0
+			rotationOffset = -90,0,0
+			scaleOffset = 0.550000012,12,0.550000012
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.313725501,0.20784314,0.0901960805,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.835294127,0.580392182,0.172549024,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 1.26388681
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 2.55895257
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _SymmetryStrength
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Symmetry
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.267944038
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 100
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1.87695859E-09
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1.05277741
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 3.13443947
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 100
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = scaleAtmo
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 2 0 0
+				key = 1 2 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = brightnessThrottle
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = brightnessAtmo
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0.3 0 0
+				key = 0.5 0.3 0 0
+				key = 0.7 0.3 0 0
+				key = 0.8 0.15 0 0
+				key = 1 0.15 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = spreadAtmo
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandLinear
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 0.7 1 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = falloffatmo
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.0500000007
+			floatName = _Falloff
+			floatCurve
+			{
+				key = 0 50 0 0
+				key = 0.2 30 0 0
+				key = 0.7 5 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = noiseAtmo
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Noise
+			floatCurve
+			{
+				key = 0 4 0 0
+				key = 0.5 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBounding
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandBounded
+			floatCurve
+			{
+				key = 0 15 0 0
+				key = 0.2 10 0 0
+				key = 0.5 1 0 0
+				key = 0.7 0 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = atmoFresnelInverse
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _FresnelInvert
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.2 0.5 0 0
+				key = 0.7 0.5 0 0
+				key = 1 0.5 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = plume2
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0
+			rotationOffset = -90,0,0
+			scaleOffset = 0.460000008,20,0.460000008
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-2
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.827450991,0.568627477,0.34117648,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.70588237,0.311524242,0.23137255,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = -5.5
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 1.25833213
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 80
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Symmetry
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1.79999995
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0.200000003
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 3.5
+				}
+				FLOAT
+				{
+					floatName = _SymmetryStrength
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.11688935
+				}
+				FLOAT
+				{
+					floatName = _Seed
+					value = 152.083115
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aExpandBound
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandBounded
+			floatCurve
+			{
+				key = 0 20 0 0
+				key = 0.2 15 0 0
+				key = 0.5 4 0 0
+				key = 0.7 3 0 0
+				key = 1 3 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = brightnessThrottle
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aFresnel
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Fresnel
+			floatCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = atmoFalloff
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Falloff
+			floatCurve
+			{
+				key = 0 70 0 0
+				key = 0.2 50 0 0
+				key = 0.7 30 0 0
+				key = 1 30 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = fadein
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _FadeIn
+			floatCurve
+			{
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tiley
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileY
+			floatCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = atmoExpLin
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName =
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightness
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 0.5 1 0 0
+				key = 0.7 0.5 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = throttleFX
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,-0.219999999
+			rotationOffset = -90,0,0
+			scaleOffset = 1,10,1
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 2,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.834054768,0.530487716,0.090082027,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.866666675,0.517647088,0.333333343,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = -0.449999988
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 1.21333146
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.657221198
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.0504999273
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 3.2355504
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 7.78554344
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.79166079
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.970665157
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 7.0777669
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 30
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 1.71888626
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 1.541942
+				}
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tScale
+			controllerName = throttle
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 5 0 0
+				key = 0.1 20 0 0
+				key = 1 50 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aScale
+			controllerName = atmosphereDepth
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 0.4 1 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = BrightnessT
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.01 0.7 0 0
+				key = 0.2 1 0 0
+				key = 0.5 0 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = BrightnessATM
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.5 0.5 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aExpandLin
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandLinear
+			floatCurve
+			{
+				key = 0 12 0 0
+				key = 0.4 6 0 0
+				key = 0.7 0.5 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.00999999978
+			rotationOffset = -90,0,0
+			scaleOffset = 0.899999976,0.899999976,0.899999976
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.639215708,0.572549045,0.4627451,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.921568632,0.698039234,0.576470613,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0.5 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock1
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,2
+			rotationOffset = -90,0,0
+			scaleOffset = 0.360000014,1.89999998,0.360000014
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.933333337,0.568627477,0.211764708,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.701960802,0.36470589,0.36470589,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = -1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 1.11222053
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 1.59249759
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1.71888626
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 40
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 6
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.616776824
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1.41555333
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 2.72999573
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.18705526
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = tPos
+			controllerName = throttle
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 0.1 0 0
+				key = 1 1 0 0
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = rPos
+			controllerName = random
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 0.8 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.01 0.05 0 0
+				key = 0.2 0.1 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.65 0 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock2
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,2
+			rotationOffset = -90,0,0
+			scaleOffset = 0.360000014,1.89999998,0.360000014
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.933333337,0.568627477,0.211764708,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.701960802,0.36470589,0.36470589,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = -1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 1.11222053
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 1.59249759
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1.71888626
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 40
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 6
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.616776824
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1.41555333
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 2.72999573
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.18705526
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = tPos
+			controllerName = throttle
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.5 0 0
+				key = 1 5 0 0
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = rPos
+			controllerName = random
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 0.94 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.01 0.05 0 0
+				key = 0.2 0.1 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.7 0 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock3
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,2
+			rotationOffset = -90,0,0
+			scaleOffset = 0.360000014,1.89999998,0.360000014
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.933333337,0.568627477,0.211764708,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.701960802,0.36470589,0.36470589,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = -1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 1.11222053
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 1.59249759
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1.71888626
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 40
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 6
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.616776824
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1.41555333
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 2.72999573
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.18705526
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = tPos
+			controllerName = throttle
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.5 0 0
+				key = 1 10 0 0
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = rPos
+			controllerName = random
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 0.96 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.01 0.05 0 0
+				key = 0.2 0.1 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.75 0 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock4
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,2
+			rotationOffset = -90,0,0
+			scaleOffset = 0.360000014,1.89999998,0.360000014
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.933333337,0.568627477,0.211764708,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.701960802,0.36470589,0.36470589,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = -1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 1.11222053
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 1.59249759
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1.71888626
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 40
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 6
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.616776824
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1.41555333
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 2.72999573
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.18705526
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = tPos
+			controllerName = throttle
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.5 0 0
+				key = 1 15 0 0
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = rPos
+			controllerName = random
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 0.96 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.01 0.05 0 0
+				key = 0.2 0.1 0 0
+				key = 1 0.4 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.8 0 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = shock5
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,2
+			rotationOffset = -90,0,0
+			scaleOffset = 0.360000014,1.89999998,0.360000014
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.933333337,0.568627477,0.211764708,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.701960802,0.36470589,0.36470589,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = -1
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 1.11222053
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 1.59249759
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 1.71888626
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 40
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 6
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0.616776824
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 1.41555333
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 2.72999573
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.18705526
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = tPos
+			controllerName = throttle
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.5 0 0
+				key = 1 20 0 0
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = rPos
+			controllerName = random
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 0.96 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBright
+			controllerName = throttle
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.01 0.05 0 0
+				key = 0.2 0.05 0 0
+				key = 1 0.2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBright
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0.85 0 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
+}

--- a/GameData/Waterfall/Templates/waterfall-methalox-lower-BE4-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-methalox-lower-BE4-1.cfg
@@ -3233,4 +3233,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.00999999978
+			rotationOffset = -90,0,0
+			scaleOffset = 0.899999976,0.899999976,0.899999976
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.490196079,0.549019635,0.819607854,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.50439018,0.392156869,0.921568632,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-methalox-lower-raptor-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-methalox-lower-raptor-1.cfg
@@ -2841,4 +2841,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.00999999978
+			rotationOffset = -90,0,0
+			scaleOffset = 0.899999976,0.899999976,0.899999976
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.490196079,0.549019635,0.819607854,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.274509817,0.392156869,0.921568632,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-methalox-upper-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-methalox-upper-1.cfg
@@ -1485,4 +1485,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0
+			rotationOffset = -90,0,0
+			scaleOffset = 0.899999976,0.899999976,0.899999976
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.635294139,0.266666681,0.223529413,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.227450982,0.215686277,0.541176498,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 3.08055115
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1.09894991
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-methalox-upper-BE4-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-methalox-upper-BE4-1.cfg
@@ -2834,4 +2834,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.00999999978
+			rotationOffset = -90,0,0
+			scaleOffset = 0.899999976,0.899999976,0.899999976
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.557115555,0.326248646,0.65978539,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.65882355,0.279417962,0.710056722,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-methalox-upper-raptor-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-methalox-upper-raptor-1.cfg
@@ -2549,4 +2549,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0.00999999978
+			rotationOffset = -90,0,0
+			scaleOffset = 0.899999976,0.899999976,0.899999976
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.557115555,0.326248646,0.65978539,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.65882355,0.279417962,0.710056722,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }

--- a/GameData/Waterfall/Templates/waterfall-methalox-vernier-1.cfg
+++ b/GameData/Waterfall/Templates/waterfall-methalox-vernier-1.cfg
@@ -1539,4 +1539,348 @@ EFFECTTEMPLATE
 			}
 		}
 	}
+	EFFECT
+	{
+		name = innerGlow
+		parentName = thrustTransform
+		MODEL
+		{
+			path = Waterfall/FX/fx-complex-plume-1
+			positionOffset = 0,0,0
+			rotationOffset = -90,0,0
+			scaleOffset = 0.200000003,0.200000003,0.200000003
+			MATERIAL
+			{
+				transform = CylinderMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.0722686052,0.361240536,0.744820535,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.573079348,0.200000003,0.0147985639,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.319856852
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.50555468
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 4.50196075
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 115.963905
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 119.778397
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 9.22637463
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.5
+				}
+			}
+			MATERIAL
+			{
+				transform = PlaneMesh
+				shader = Waterfall/Additive Directional
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-1
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 0.639215708,0.572549045,0.4627451,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.921568632,0.698039234,0.576470613,0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0.300000012
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 9
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.400000006
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedX
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 50
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _TileY
+					value = 3
+				}
+				FLOAT
+				{
+					floatName = _DirAdjust
+					value = 0.200000003
+				}
+			}
+		}
+		POSITIONMODIFIER
+		{
+			name = aTailPos
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+			}
+			yCurve
+			{
+				key = 0 -20 0 0
+				key = 1 -25 0 0
+			}
+			zCurve
+			{
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = tExitScale
+			controllerName = throttle
+			transformName = B_Exit
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1.25 0 0
+			}
+			yCurve
+			{
+			}
+			zCurve
+			{
+				key = 0 1.25 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = aTailScale
+			controllerName = atmosphereDepth
+			transformName = B_Tail
+			combinationType = REPLACE
+			useRandomness = True
+			randomnessController = random
+			randomnessScale = 0.5
+			xCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+			yCurve
+			{
+				key = 0 3 0 0
+			}
+			zCurve
+			{
+				key = 0 11 0 0
+				key = 0.1 8 0 0
+				key = 0.2 7 0 0
+				key = 0.5 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = throatScale
+			controllerName = throttle
+			transformName = B_Throat
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 0.5 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+			}
+			zCurve
+			{
+				key = 0 0.5 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = exit1Scale
+			controllerName = atmosphereDepth
+			transformName = B_PostExit1
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+			yCurve
+			{
+				key = 0 0.5 0 0
+				key = 1 1 0 0
+			}
+			zCurve
+			{
+				key = 0 2.5 0 0
+				key = 0.1 1.9 0 0
+				key = 0.2 1.75 0 0
+				key = 0.5 1.5 0 0
+				key = 0.7 1.2 0 0
+				key = 1 0.8 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tBrightnessFlat
+			controllerName = throttle
+			transformName = PlaneMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.7 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = tilex
+			controllerName = atmosphereDepth
+			transformName = CylinderMesh
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _TileX
+			floatCurve
+			{
+				key = 0 9 0 0
+				key = 1 2 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = aBrightFlat
+			controllerName = atmosphereDepth
+			transformName = PlaneMesh
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0.5 0 0
+				key = 0.7 1.5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
 }


### PR DESCRIPTION
Adds a soft engine glow to the newly added templates that helps blend emissives into the plume. Not a subsitute for a good internal emissive but helps make ones that do have it work better with the plume.

New keroxide lower template.

![screenshot136](https://user-images.githubusercontent.com/39182212/108527033-a5403500-72f3-11eb-811a-236378a6541d.png)
