### PR TITLE
Add conformal decals shader blacklist patch

### DIFF
--- a/GameData/Waterfall/Patches/WaterfallConformalDecals.cfg
+++ b/GameData/Waterfall/Patches/WaterfallConformalDecals.cfg
@@ -1,0 +1,13 @@
+@CONFORMALDECALS:NEEDS[ConformalDecals] {
+    %SHADERBLACKLIST {
+        shader = Waterfall/Additive Directional
+        shader = Waterfall/Additive (Dynamic)
+        shader = Waterfall/Additive
+        shader = Waterfall/Alpha Directional
+        shader = Waterfall/Alpha (Dynamic)
+        shader = Waterfall/Billboard (Additive)
+        shader = Waterfall/Billboard (Additive Directional)
+        shader = Waterfall/Distortion (Dynamic)
+        shader = Waterfall/Additive Detail (Dynamic)
+    }
+}

--- a/GameData/Waterfall/Patches/WaterfallConformalDecals.cfg
+++ b/GameData/Waterfall/Patches/WaterfallConformalDecals.cfg
@@ -1,3 +1,5 @@
+// Blacklist waterfall plumes to prevent Conformal Decals from projecting onto them 
+
 @CONFORMALDECALS:NEEDS[ConformalDecals] {
     %SHADERBLACKLIST {
         shader = Waterfall/Additive Directional


### PR DESCRIPTION
This prevents Conformal Decals from trying to project onto waterfall plumes. I think it should go in the waterfall repo so new shaders in waterfall don't need Conformal Decals to update to keep up.