### PR TITLE
Controller updates

### DIFF
--- a/Source/Waterfall/EffectControllers/EventController.cs
+++ b/Source/Waterfall/EffectControllers/EventController.cs
@@ -19,7 +19,7 @@ namespace Waterfall
     bool eventPlaying = false;
     bool eventReady = false;
     float eventTime = 0f;
-    float eventDuration = 1f;
+    public float eventDuration = 1f;
 
     public EngineEventController() { }
     public EngineEventController(ConfigNode node)
@@ -93,10 +93,10 @@ namespace Waterfall
 
     public float CheckStateChange()
     {
-      
+
       if (eventReady)
       {
-        /// Check if engine state flipped 
+        /// Check if engine state flipped
         if (engineController.EngineIgnited != enginePreState)
         {
           Utils.Log($"[EngineEventController] {eventName} fired ", LogType.Modifiers);

--- a/Source/Waterfall/EffectControllers/RCSController.cs
+++ b/Source/Waterfall/EffectControllers/RCSController.cs
@@ -1,19 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using UnityEngine;
 
 namespace Waterfall
 {
-
   /// <summary>
-  /// A controller that pulls from throttle settings
+  /// A controller that pulls from RCS throttle
   /// </summary>
   [Serializable]
   public class RCSController : WaterfallController
   {
-    public float currentThrottle = 1;
+    public List<float> currentThrottle;
+    public float responseRateUp = 100f;
+    public float responseRateDown = 100f;
     public string thrusterTransformName = "";
     ModuleRCSFX rcsController;
     public RCSController() { }
@@ -22,26 +22,37 @@ namespace Waterfall
       name = "rcs";
       linkedTo = "rcs";
       node.TryGetValue("name", ref name);
+      node.TryGetValue("responseRateUp", ref responseRateUp);
+      node.TryGetValue("responseRateDown", ref responseRateDown);
       node.TryGetValue("thrusterTransformName", ref thrusterTransformName);
     }
     public override void Initialize(ModuleWaterfallFX host)
     {
       base.Initialize(host);
 
-
       rcsController = host.GetComponents<ModuleRCSFX>().ToList().Find(x => x.thrusterTransformName == thrusterTransformName);
       if (rcsController == null)
         rcsController = host.GetComponent<ModuleRCSFX>();
 
       if (rcsController == null)
+      {
         Utils.LogError("[RCSController] Could not find ModuleRCSFX on Initialize");
+        return;
+      }
 
+      currentThrottle = new List<float>(rcsController.thrusterTransforms.Count);
+      for (int i = 0; i < rcsController.thrusterTransforms.Count; i++)
+      {
+        currentThrottle.Add(0f);
+      }
     }
 
     public override ConfigNode Save()
     {
-      ConfigNode c =  base.Save();
+      ConfigNode c = base.Save();
 
+      c.AddValue("responseRateUp", responseRateUp);
+      c.AddValue("responseRateDown", responseRateDown);
       c.AddValue("thrusterTransformName", thrusterTransformName);
       return c;
     }
@@ -52,20 +63,25 @@ namespace Waterfall
         Utils.LogWarning("[RCSController] RCS controller not assigned");
         return new List<float>() { 0f };
       }
+
       if (overridden)
       {
-        List<float> overrideValues = new List<float>();
-        for (int i=0; i< rcsController.thrusterTransforms.Count; i++)
+        var overrideValues = new List<float>(rcsController.thrusterTransforms.Count);
+        for (int i = 0; i < rcsController.thrusterTransforms.Count; i++)
         {
           overrideValues.Add(overrideValue);
         }
         return overrideValues;
       }
 
-    
-      return (rcsController.thrustForces).ToList().Select(x => x/rcsController.thrusterPower).ToList();
-      
+      for (int i = 0; i < currentThrottle.Count; i++)
+      {
+        var newThrottle = rcsController.thrustForces[i] / rcsController.thrusterPower;
+        var responseRate = newThrottle > currentThrottle[i] ? responseRateUp : responseRateDown;
+        currentThrottle[i] = Mathf.MoveTowards(currentThrottle[i], newThrottle, responseRate * TimeWarp.deltaTime);
+      }
+
+      return new List<float>(currentThrottle);
     }
   }
-
 }

--- a/Source/Waterfall/EffectControllers/ThrustController.cs
+++ b/Source/Waterfall/EffectControllers/ThrustController.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Waterfall
+{
+
+  /// <summary>
+  /// A controller that pulls from the current engine's thrust. Returns a fractional thrust value
+  /// normalized to [0, 1] where 1 corresponds to the max thrust possible under current conditions.
+  /// </summary>
+  [System.Serializable]
+  public class ThrustController : WaterfallController
+  {
+    public string engineID = "";
+    public float currentThrustFraction;
+    ModuleEngines engineController;
+
+    public ThrustController() { }
+    public ThrustController(ConfigNode node)
+    {
+      name = "thrust";
+      linkedTo = "thrust";
+      engineID = "";
+      node.TryGetValue("name", ref name);
+      node.TryGetValue("engineID", ref engineID);
+    }
+    public override void Initialize(ModuleWaterfallFX host)
+    {
+      base.Initialize(host);
+
+      engineController = host.GetComponents<ModuleEngines>().ToList().Find(x => x.engineID == engineID);
+      if (engineController == null)
+      {
+        Utils.Log($"[ThrustController] Could not find engine ID {engineID}, using first module");
+        engineController = host.GetComponent<ModuleEngines>();
+      }
+
+      if (engineController == null)
+        Utils.LogError("[ThrustController] Could not find engine controller on Initialize");
+
+    }
+    public override ConfigNode Save()
+    {
+      ConfigNode c = base.Save();
+
+      c.AddValue("engineID", engineID);
+      return c;
+    }
+    public override List<float> Get()
+    {
+
+      if (overridden)
+        return new List<float>() { overrideValue };
+
+      if (engineController == null)
+      {
+        Utils.LogWarning("[ThrustController] Engine controller not assigned");
+        return new List<float>() { 0f };
+      }
+
+      if (!engineController.isOperational)
+        currentThrustFraction = 0f;
+      else
+      {
+        // Thanks to NathanKell for the formula.
+        currentThrustFraction = engineController.fuelFlowGui
+          / (engineController.maxFuelFlow * 1000f)
+          / (float)engineController.ratioSum
+          * engineController.mixtureDensity
+          * engineController.multIsp;
+      }
+
+      return new List<float>() { currentThrustFraction };
+    }
+  }
+}

--- a/Source/Waterfall/Modules/ModuleWaterfallFX.cs
+++ b/Source/Waterfall/Modules/ModuleWaterfallFX.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -46,7 +46,6 @@ namespace Waterfall
 
       Utils.Log($"[ModuleWaterfallFX]: OnLoad called with contents \n{node.ToString()}", LogType.Modules);
 
-      ConfigNode[] controllerNodes = node.GetNodes(WaterfallConstants.ControllerNodeName);
       ConfigNode[] effectNodes = node.GetNodes(WaterfallConstants.EffectNodeName);
       ConfigNode[] templateNodes = node.GetNodes(WaterfallConstants.TemplateNodeName);
 
@@ -56,79 +55,7 @@ namespace Waterfall
         CleanupEffects();
       }
 
-      if (allControllers == null || allControllers.Count == 0)
-      {
-        Utils.Log(String.Format("[ModuleWaterfallFX]: Loading Controllers on moduleID {0}", moduleID), LogType.Modules);
-        allControllers = new Dictionary<string, WaterfallController>();
-        foreach (ConfigNode controllerDataNode in controllerNodes)
-        {
-          string ctrlType = "throttle";
-          if (!controllerDataNode.TryGetValue("linkedTo", ref ctrlType))
-          {
-            Utils.LogWarning(String.Format("[ModuleWaterfallFX]: Controller on moduleID {0} does not define linkedTo, setting throttle as default ", moduleID));
-          }
-          if (ctrlType == "throttle")
-          {
-            ThrottleController tCtrl = new ThrottleController(controllerDataNode);
-            allControllers.Add(tCtrl.name, tCtrl);
-            Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Throttle Controller on moduleID {0}", moduleID), LogType.Modules);
-          }
-          if (ctrlType == "atmosphere_density")
-          {
-            AtmosphereDensityController aCtrl = new AtmosphereDensityController(controllerDataNode);
-            allControllers.Add(aCtrl.name, aCtrl);
-            Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Atmosphere Density Controller on moduleID {0}", moduleID), LogType.Modules);
-          }
-          if (ctrlType == "custom")
-          {
-            CustomController cCtrl = new CustomController(controllerDataNode);
-            allControllers.Add(cCtrl.name, cCtrl);
-            Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Custom Controller on moduleID {0}", moduleID), LogType.Modules);
-          }
-          if (ctrlType == "rcs")
-          {
-            RCSController rcsCtrl = new RCSController(controllerDataNode);
-            allControllers.Add(rcsCtrl.name, rcsCtrl);
-            Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded RCS Controller on moduleID {0}", moduleID), LogType.Modules);
-          }
-          if (ctrlType == "random")
-          {
-            RandomnessController rCtrl = new RandomnessController(controllerDataNode);
-
-            allControllers.Add(rCtrl.name, rCtrl);
-
-            Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Randomness Controller on moduleID {0}", moduleID), LogType.Modules);
-          }
-          if (ctrlType == "light")
-          {
-            LightController rCtrl = new LightController(controllerDataNode);
-
-            allControllers.Add(rCtrl.name, rCtrl);
-            Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Randomness Controller on moduleID {0}", moduleID), LogType.Modules);
-          }
-          if (ctrlType == "engineEvent")
-          {
-            EngineEventController rCtrl = new EngineEventController(controllerDataNode);
-
-            allControllers.Add(rCtrl.name, rCtrl);
-            Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Engine Event Controller on moduleID {0}", moduleID), LogType.Modules);
-          }
-          if (ctrlType == "mach")
-          {
-            MachController rCtrl = new MachController(controllerDataNode);
-
-            allControllers.Add(rCtrl.name, rCtrl);
-            Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Mach Controller on moduleID {0}", moduleID), LogType.Modules);
-          }
-          if (ctrlType == "gimbal")
-          {
-            GimbalController rCtrl = new GimbalController(controllerDataNode);
-
-            allControllers.Add(rCtrl.name, rCtrl);
-            Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Gimbal Controller on moduleID {0}", moduleID), LogType.Modules);
-          }
-        }
-      }
+      LoadControllers(node);
 
       Utils.Log(String.Format("[ModuleWaterfallFX]: Loading Effects on moduleID {0}", moduleID), LogType.Modules);
 
@@ -368,30 +295,26 @@ namespace Waterfall
           }
           if (ctrlType == "light")
           {
-            LightController rCtrl = new LightController(controllerDataNode);
-
-            allControllers.Add(rCtrl.name, rCtrl);
-            Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Randomness Controller on moduleID {0}", moduleID), LogType.Modules);
+            LightController lCtrl = new LightController(controllerDataNode);
+            allControllers.Add(lCtrl.name, lCtrl);
+            Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Light Controller on moduleID {0}", moduleID), LogType.Modules);
           }
           if (ctrlType == "engineEvent")
           {
-            EngineEventController rCtrl = new EngineEventController(controllerDataNode);
-
-            allControllers.Add(rCtrl.name, rCtrl);
+            EngineEventController eEvtCtrl = new EngineEventController(controllerDataNode);
+            allControllers.Add(eEvtCtrl.name, eEvtCtrl);
             Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Engine Event Controller on moduleID {0}", moduleID), LogType.Modules);
           }
           if (ctrlType == "mach")
           {
-            MachController rCtrl = new MachController(controllerDataNode);
-
-            allControllers.Add(rCtrl.name, rCtrl);
+            MachController mCtrl = new MachController(controllerDataNode);
+            allControllers.Add(mCtrl.name, mCtrl);
             Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Mach Controller on moduleID {0}", moduleID), LogType.Modules);
           }
           if (ctrlType == "gimbal")
           {
-            GimbalController rCtrl = new GimbalController(controllerDataNode);
-
-            allControllers.Add(rCtrl.name, rCtrl);
+            GimbalController gCtrl = new GimbalController(controllerDataNode);
+            allControllers.Add(gCtrl.name, gCtrl);
             Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Gimbal Controller on moduleID {0}", moduleID), LogType.Modules);
           }
         }

--- a/Source/Waterfall/Modules/ModuleWaterfallFX.cs
+++ b/Source/Waterfall/Modules/ModuleWaterfallFX.cs
@@ -317,9 +317,16 @@ namespace Waterfall
             allControllers.Add(gCtrl.name, gCtrl);
             Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Gimbal Controller on moduleID {0}", moduleID), LogType.Modules);
           }
+          if (ctrlType == "thrust")
+          {
+            ThrustController tcCtrl = new ThrustController(controllerDataNode);
+            allControllers.Add(tcCtrl.name, tcCtrl);
+            Utils.Log(String.Format("[ModuleWaterfallFX]: Loaded Thrust Curve Controller on moduleID {0}", moduleID), LogType.Modules);
+          }
         }
       }
     }
+
     ConfigNode FetchConfig()
     {
       Utils.Log(String.Format("[ModuleWaterfallFX]: Finding config for {0}", moduleID), LogType.Modules);

--- a/Source/Waterfall/UI/UIControllerPopupWindow.cs
+++ b/Source/Waterfall/UI/UIControllerPopupWindow.cs
@@ -54,6 +54,8 @@ namespace Waterfall.UI
     string[] eventTypes = new string[] { "ignition", "flameout" };
     int eventFlag = 0;
     FloatCurve eventCurve = new FloatCurve();
+    float eventDuration = 2f;
+    string eventDurationString = "";
 
     public UIControllerPopupWindow(bool show) : base(show)
     {
@@ -98,6 +100,8 @@ namespace Waterfall.UI
       else if (control is EngineEventController e)
       {
         eventCurve = e.eventCurve;
+        eventDuration = e.eventDuration;
+        eventDurationString = e.eventDuration.ToString();
       }
       else if (control is ThrottleController t)
       {
@@ -272,6 +276,7 @@ namespace Waterfall.UI
         newCtrl.linkedTo = controllerTypes[controllerFlag];
         newCtrl.eventName = eventTypes[eventFlag];
         newCtrl.eventCurve = eventCurve;
+        newCtrl.eventDuration = eventDuration;
         return newCtrl;
       }
       else if (controllerTypes[controllerFlag] == "gimbal")
@@ -370,6 +375,18 @@ namespace Waterfall.UI
           EditCurve(eventCurve, eventFun);
         }
         GUI.DrawTexture(imageRect, miniCurve);
+        GUILayout.BeginHorizontal();
+        GUILayout.Label("Event duration", GUIResources.GetStyle("data_header"), GUILayout.MaxWidth(160f));
+        eventDurationString = GUILayout.TextArea(eventDurationString, GUILayout.MaxWidth(60f));
+        float floatParsed;
+        if (float.TryParse(eventDurationString, out floatParsed))
+        {
+          if (eventDuration != floatParsed)
+          {
+            eventDuration = floatParsed;
+          }
+        }
+        GUILayout.EndHorizontal();
 
       }
       else if (controllerTypes[controllerFlag] == "gimbal")

--- a/Source/Waterfall/UI/UIControllerPopupWindow.cs
+++ b/Source/Waterfall/UI/UIControllerPopupWindow.cs
@@ -1,10 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
 using UnityEngine;
-using Waterfall;
 
 namespace Waterfall.UI
 {
@@ -84,9 +79,9 @@ namespace Waterfall.UI
       windowMode = ControllerPopupMode.Modify;
       WindowPosition = new Rect(Screen.width / 2 - 100, Screen.height / 2f - 50, 400, 100);
       eventCurve = new FloatCurve();
-      try
+
+      if (control is RandomnessController r)
       {
-        RandomnessController r = (RandomnessController)control;
         if (r.noiseType == "random")
         {
           randomStrings[0] = r.range.x.ToString();
@@ -94,23 +89,27 @@ namespace Waterfall.UI
         }
         if (r.noiseType == "perlin")
         {
-          
           randomStrings[0] = r.seed.ToString();
           randomStrings[1] = r.scale.ToString();
           randomStrings[2] = r.speed.ToString();
           randomStrings[3] = r.minimum.ToString();
         }
-        EngineEventController e = (EngineEventController)control;
-        ThrottleController t = (ThrottleController)control;
-
-          throttleStrings[0] = t.responseRateUp.ToString();
-          throttleStrings[1] = t.responseRateDown.ToString();
-        
-        eventCurve = e.eventCurve;
-        
       }
-      catch( Exception)
-      { }
+      else if (control is EngineEventController e)
+      {
+        eventCurve = e.eventCurve;
+      }
+      else if (control is ThrottleController t)
+      {
+        throttleStrings[0] = t.responseRateUp.ToString();
+        throttleStrings[1] = t.responseRateDown.ToString();
+      }
+      else if (control is RCSController rcs)
+      {
+        throttleStrings[0] = rcs.responseRateUp.ToString();
+        throttleStrings[1] = rcs.responseRateDown.ToString();
+      }
+
       GenerateCurveThumbs();
     }
     public void SetAddMode(ModuleWaterfallFX mod)
@@ -121,7 +120,7 @@ namespace Waterfall.UI
       controllerFlag = 0;
       WindowPosition = new Rect(Screen.width / 2, Screen.height / 2f, 400, 400);
       eventCurve = new FloatCurve();
-      eventCurve.Add(0f,0f);
+      eventCurve.Add(0f, 0f);
       eventCurve.Add(0.1f, 1f);
       eventCurve.Add(1f, 0f);
       GenerateCurveThumbs();
@@ -315,6 +314,8 @@ namespace Waterfall.UI
         RCSController newCtrl = new RCSController();
         newCtrl.name = newControllerName;
         newCtrl.linkedTo = controllerTypes[controllerFlag];
+        newCtrl.responseRateUp = rampRateUp;
+        newCtrl.responseRateDown = rampRateDown;
         return newCtrl;
       }
       else if (controllerTypes[controllerFlag] == "throttle")
@@ -472,7 +473,7 @@ namespace Waterfall.UI
           GUILayout.BeginHorizontal();
           GUILayout.Label("Speed", GUIResources.GetStyle("data_header"), GUILayout.MaxWidth(160f));
           randomStrings[2] = GUILayout.TextArea(randomStrings[2], GUILayout.MaxWidth(60f));
-          
+
           if (float.TryParse(randomStrings[2], out floatParsed))
           {
             if (perlinSpeed != floatParsed)
@@ -485,7 +486,30 @@ namespace Waterfall.UI
       }
       else if (controllerTypes[controllerFlag] == "rcs")
       {
-        // no special config
+        GUILayout.BeginHorizontal();
+        GUILayout.Label("Ramp Rate Up", GUIResources.GetStyle("data_header"), GUILayout.MaxWidth(160f));
+        throttleStrings[0] = GUILayout.TextArea(throttleStrings[0], GUILayout.MaxWidth(60f));
+        float floatParsed;
+        if (float.TryParse(throttleStrings[0], out floatParsed))
+        {
+          if (rampRateUp != floatParsed)
+          {
+            rampRateUp = floatParsed;
+          }
+        }
+        GUILayout.EndHorizontal();
+
+        GUILayout.BeginHorizontal();
+        GUILayout.Label("Ramp Rate Down", GUIResources.GetStyle("data_header"), GUILayout.MaxWidth(160f));
+        throttleStrings[1] = GUILayout.TextArea(throttleStrings[1], GUILayout.MaxWidth(60f));
+        if (float.TryParse(throttleStrings[1], out floatParsed))
+        {
+          if (rampRateDown != floatParsed)
+          {
+            rampRateDown = floatParsed;
+          }
+        }
+        GUILayout.EndHorizontal();
       }
       else if (controllerTypes[controllerFlag] == "throttle")
       {

--- a/Source/Waterfall/UI/UIControllerPopupWindow.cs
+++ b/Source/Waterfall/UI/UIControllerPopupWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -31,7 +31,7 @@ namespace Waterfall.UI
     WaterfallController control;
     ModuleWaterfallFX fxMod;
     string newControllerName = "controller";
-    string[] controllerTypes = new string[] { "atmosphere_density", "custom", "engineEvent", "gimbal", "light", "mach", "random", "rcs", "throttle" };
+    string[] controllerTypes = new string[] { "atmosphere_density", "custom", "engineEvent", "gimbal", "light", "mach", "random", "rcs", "throttle", "thrust" };
     int controllerFlag = 0;
     CurveUpdateFunction eventFun;
 
@@ -327,6 +327,13 @@ namespace Waterfall.UI
         newCtrl.responseRateDown = rampRateDown;
         return newCtrl;
       }
+      else if (controllerTypes[controllerFlag] == "thrust")
+      {
+        ThrustController newCtrl = new ThrustController();
+        newCtrl.name = newControllerName;
+        newCtrl.linkedTo = controllerTypes[controllerFlag];
+        return newCtrl;
+      }
       else
       {
         return null;
@@ -506,6 +513,10 @@ namespace Waterfall.UI
           }
         }
         GUILayout.EndHorizontal();
+      }
+      else if (controllerTypes[controllerFlag] == "thrust")
+      {
+        // no special config
       }
     }
     protected void GenerateCurveThumbs()


### PR DESCRIPTION
This patch makes several changes relating to controllers:

- Introduce a new `ThrustController`. This controller, in contrast to the `ThrottleController` that reads from throttle, provides a normalized thrust value where the maximum possible thrust under current conditions is 1. This is useful because it responds to thrust curves, for example.
- Add response rate support for the RCS controller. This is useful for replicating some IRL thrusters, for example this footage from a Soyuz: https://youtu.be/gWJ-VxNPs5Q?t=3170 (note how the plume dissipates gradually).
- Expose the event duration field in the in-game editor for the engine event controller.

It also does some minor refactoring:

- Remove some code duplication in `ModuleWaterfallFX.OnLoad()` by using the existing method `ModuleWaterfallFX.LoadControllers()`. This, as far as I can tell, should be equivalent.
- Use [type patterns](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/patterns#declaration-and-type-patterns) to load data from controllers without throwing exceptions in `UIControllerPopupWindow.SetEditMode()`.