### PR TITLE
Allow templates and other configurations to be patched via MM

### DIFF
--- a/Source/Waterfall/WaterfallData.cs
+++ b/Source/Waterfall/WaterfallData.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using UnityEngine;
-using System.IO;
+﻿using UnityEngine;
 
 namespace Waterfall
 {
@@ -12,8 +6,8 @@ namespace Waterfall
   /// Class to load shaders and config level data for the mod.
   /// </summary>
   [KSPAddon(KSPAddon.Startup.Instantly, false)]
-  public  class WaterfallData: MonoBehaviour
-  { 
+  public class WaterfallData : MonoBehaviour
+  {
 
     public bool FirstLoad = true;
     public static WaterfallData Instance { get; private set; }
@@ -23,13 +17,12 @@ namespace Waterfall
       Instance = this;
     }
 
-    protected void Start()
+    public static void ModuleManagerPostLoad()
     {
       WaterfallParticleLoader.LoadParticles();
       ShaderLoader.LoadShaders();
       ShaderLoader.LoadShaderProperties();
       WaterfallTemplates.LoadTemplates();
     }
-    
   }
 }


### PR DESCRIPTION
Waterfall used to load templates before ModuleManager has finished patching, resulting in the MM changes not being picked up. This PR fixes MM patching by loading all Waterfall data after ModuleManager finishes running patches.

For information on `ModuleManagerPostLoad`, see https://github.com/sarbian/ModuleManager/blob/838677db5f2d2c17c1ce653489a3caa974110009/ModuleManager/PostPatchLoader.cs#L152-L178.