### PR TITLE
Fix scale integrators compounding on themselves

### DIFF
--- a/Source/Waterfall/Effects/EffectIntegrators/EffectScaleIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectScaleIntegrator.cs
@@ -24,7 +24,7 @@ namespace Waterfall
     {
       if (handledModifiers.Count == 0)
         return;
-      Array.Copy(initialValues, modifierData, initialValues.Length);
+      Array.Copy(initialValues, workingValues, initialValues.Length);
 
       foreach (var mod in handledModifiers)
       {


### PR DESCRIPTION
-initial values were being copied to the wrong array instead of being used as the starting point for integration
-I checked all the other integrator types and they were correct already