### PR TITLE
Convert many foreach loops to for loops to improve performance

### DIFF
--- a/Source/Waterfall/EffectModifiers/EffectModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectModifier.cs
@@ -92,8 +92,9 @@ namespace Waterfall
       Utils.Log($"[EffectModifier]: Initializing modifier {fxName}", LogType.Modifiers);
       var roots = parentEffect.GetModelTransforms();
       xforms = new();
-      foreach (var t in roots)
+      for (int i = 0; i < roots.Count; i++)
       {
+        var t  = roots[i];
         var t1 = t.FindDeepChild(transformName);
         if (t1 == null)
         {

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectColorIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectColorIntegrator.cs
@@ -53,12 +53,13 @@ namespace Waterfall
       
       Array.Copy(initialValues, workingValues, m.Length);
 
-      foreach (var mod in handledModifiers)
+      for (int i = 0; i < handledModifiers.Count; i++)
       {
+        var mod = handledModifiers[i];
         if (mod.Controller != null)
         {
           float[] controllerData = mod.Controller.Get();
-          ((EffectColorModifier)mod).Get(controllerData, modifierData);
+          ((EffectColorModifier) mod).Get(controllerData, modifierData);
           Integrate(mod.effectMode, workingValues, modifierData);
         }
       }

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectFloatIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectFloatIntegrator.cs
@@ -29,8 +29,9 @@ namespace Waterfall
       parentEffect = effect;
 
       var roots = parentEffect.GetModelTransforms();
-      foreach (var t in roots)
+      for (int i = 0; i < roots.Count; i++)
       {
+        var t = roots[i];
         if (t.FindDeepChild(transformName) is Transform t1 && t1 != null)
           xforms.Add(t1);
         else
@@ -152,19 +153,21 @@ namespace Waterfall
       s_ListPrep.End();
 
       s_Modifiers.Begin();
-      foreach (var mod in handledModifiers)
+      for (int i = 0; i < handledModifiers.Count; i++)
       {
+        var mod = handledModifiers[i];
         if (mod.Controller != null)
         {
           float[] controllerData = mod.Controller.Get();
 
-          ((EffectFloatModifier)mod).Get(controllerData, modifierData);
+          ((EffectFloatModifier) mod).Get(controllerData, modifierData);
 
           s_Integrate.Begin();
           Integrate(mod.effectMode, workingValues, modifierData);
           s_Integrate.End();
         }
       }
+
       s_Modifiers.End();
 
       s_Apply.Begin();

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectLightColorIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectLightColorIntegrator.cs
@@ -35,12 +35,13 @@ namespace Waterfall
         return;
       Array.Copy(initialValues, workingValues, l.Length);
 
-      foreach (var mod in handledModifiers)
+      for (int i = 0; i < handledModifiers.Count; i++)
       {
+        var mod = handledModifiers[i];
         if (mod.Controller != null)
         {
           float[] controllerData = mod.Controller.Get();
-          ((EffectLightColorModifier)mod).Get(controllerData, modifierData);
+          ((EffectLightColorModifier) mod).Get(controllerData, modifierData);
           Integrate(mod.effectMode, workingValues, modifierData);
         }
       }

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectLightFloatIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectLightFloatIntegrator.cs
@@ -44,12 +44,13 @@ namespace Waterfall
 
       Array.Copy(initialValues, workingValues, l.Length);
 
-      foreach (var mod in handledModifiers)
+      for (int i = 0; i < handledModifiers.Count; i++)
       {
+        var mod = handledModifiers[i];
         if (mod.Controller != null)
         {
           float[] controllerData = mod.Controller.Get();
-          ((EffectLightFloatModifier)mod).Get(controllerData, modifierData);
+          ((EffectLightFloatModifier) mod).Get(controllerData, modifierData);
           Integrate(mod.effectMode, workingValues, modifierData);
         }
       }

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectPositionIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectPositionIntegrator.cs
@@ -25,13 +25,14 @@ namespace Waterfall
       if (handledModifiers.Count == 0)
         return;
       Array.Copy(initialValues, workingValues, initialValues.Length);
-      
-      foreach (var mod in handledModifiers)
+
+      for (int i = 0; i < handledModifiers.Count; i++)
       {
+        var mod = handledModifiers[i];
         if (mod.Controller != null)
         {
           float[] controllerData = mod.Controller?.Get();
-          ((EffectPositionModifier)mod).Get(controllerData, modifierData);
+          ((EffectPositionModifier) mod).Get(controllerData, modifierData);
           Integrate(mod.effectMode, workingValues, modifierData);
         }
       }

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectRotationIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectRotationIntegrator.cs
@@ -26,12 +26,13 @@ namespace Waterfall
         return;
       Array.Copy(initialValues, workingValues, initialValues.Length);
 
-      foreach (var mod in handledModifiers)
+      for (int i = 0; i < handledModifiers.Count; i++)
       {
+        var mod = handledModifiers[i];
         if (mod.Controller != null)
         {
           float[] controllerData = mod.Controller.Get();
-          ((EffectRotationModifier)mod).Get(controllerData, modifierData);
+          ((EffectRotationModifier) mod).Get(controllerData, modifierData);
           Integrate(mod.effectMode, workingValues, modifierData);
         }
       }

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectScaleIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectScaleIntegrator.cs
@@ -26,12 +26,13 @@ namespace Waterfall
         return;
       Array.Copy(initialValues, workingValues, initialValues.Length);
 
-      foreach (var mod in handledModifiers)
+      for (int i = 0; i < handledModifiers.Count; i++)
       {
+        var mod = handledModifiers[i];
         if (mod.Controller != null)
         {
           float[] controllerData = mod.Controller.Get();
-          ((EffectScaleModifier)mod).Get(controllerData, modifierData);
+          ((EffectScaleModifier) mod).Get(controllerData, modifierData);
           Integrate(mod.effectMode, workingValues, modifierData);
         }
       }

--- a/Source/Waterfall/Effects/WaterfallEffect.cs
+++ b/Source/Waterfall/Effects/WaterfallEffect.cs
@@ -119,48 +119,57 @@ namespace Waterfall
       var lightFloatNodes = node.GetNodes(WaterfallConstants.LightFloatModifierNodeName);
       var lightColorNodes = node.GetNodes(WaterfallConstants.LightColorModifierNodeName);
 
-      foreach (var subNode in positionNodes)
+      for (int i = 0; i < positionNodes.Length; i++)
       {
+        var subNode = positionNodes[i];
         fxModifiers.Add(new EffectPositionModifier(subNode));
       }
 
-      foreach (var subNode in rotationNodes)
+      for (int i = 0; i < rotationNodes.Length; i++)
       {
+        var subNode = rotationNodes[i];
         fxModifiers.Add(new EffectRotationModifier(subNode));
       }
 
-      foreach (var subNode in scalingNodes)
+      for (int i = 0; i < scalingNodes.Length; i++)
       {
+        var subNode = scalingNodes[i];
         fxModifiers.Add(new EffectScaleModifier(subNode));
       }
 
-      foreach (var subNode in colorNodes)
+      for (int i = 0; i < colorNodes.Length; i++)
       {
+        var subNode = colorNodes[i];
         fxModifiers.Add(new EffectColorModifier(subNode));
       }
 
-      foreach (var subNode in uvOffsetNodes)
+      for (int i = 0; i < uvOffsetNodes.Length; i++)
       {
+        var subNode = uvOffsetNodes[i];
         fxModifiers.Add(new EffectUVScrollModifier(subNode));
       }
 
-      foreach (var subNode in floatNodes)
+      for (int i = 0; i < floatNodes.Length; i++)
       {
+        var subNode = floatNodes[i];
         fxModifiers.Add(new EffectFloatModifier(subNode));
       }
 
-      foreach (var subNode in colorLightNodes)
+      for (int i = 0; i < colorLightNodes.Length; i++)
       {
+        var subNode = colorLightNodes[i];
         fxModifiers.Add(new EffectColorFromLightModifier(subNode));
       }
 
-      foreach (var subNode in lightFloatNodes)
+      for (int i = 0; i < lightFloatNodes.Length; i++)
       {
+        var subNode = lightFloatNodes[i];
         fxModifiers.Add(new EffectLightFloatModifier(subNode));
       }
 
-      foreach (var subNode in lightColorNodes)
+      for (int i = 0; i < lightColorNodes.Length; i++)
       {
+        var subNode = lightColorNodes[i];
         fxModifiers.Add(new EffectLightColorModifier(subNode));
       }
     }
@@ -231,18 +240,22 @@ namespace Waterfall
         effectTransforms.Add(effectTransform);
       }
 
-      foreach (var fx in fxModifiers)
+      for (int j = 0; j < fxModifiers.Count; j++)
       {
+        var fx = fxModifiers[j];
         fx.Init(this);
       }
 
       effectRenderers.Clear();
       effectRendererMaterials.Clear();
       effectRendererTransforms.Clear();
-      foreach (var t in model.modelTransforms)
+      for (int transformIndex = 0; transformIndex < model.modelTransforms.Count; transformIndex++)
       {
-        foreach (var r in t.GetComponentsInChildren<Renderer>())
+        var t  = model.modelTransforms[transformIndex];
+        var rs = t.GetComponentsInChildren<Renderer>();
+        for (int rendererIndex = 0; rendererIndex < rs.Length; rendererIndex++)
         {
+          var r = rs[rendererIndex];
           effectRenderers.Add(r);
           effectRendererMaterials.Add(r.material);
           effectRendererTransforms.Add(r.transform);
@@ -262,15 +275,23 @@ namespace Waterfall
       lightFloatIntegrators.Clear();
       lightColorIntegrators.Clear();
 
-      foreach (var mod in fxModifiers)
+      for (int i = 0; i < fxModifiers.Count; i++)
       {
-        if (mod is EffectFloatModifier) mod.CreateOrAttachToIntegrator(floatIntegrators);
-        else if (mod is EffectColorModifier) mod.CreateOrAttachToIntegrator(colorIntegrators);
-        else if (mod is EffectPositionModifier) mod.CreateOrAttachToIntegrator(positionIntegrators);
-        else if (mod is EffectRotationModifier) mod.CreateOrAttachToIntegrator(rotationIntegrators);
-        else if (mod is EffectScaleModifier) mod.CreateOrAttachToIntegrator(scaleIntegrators);
-        else if (mod is EffectLightFloatModifier) mod.CreateOrAttachToIntegrator(lightFloatIntegrators);
-        else if (mod is EffectLightColorModifier) mod.CreateOrAttachToIntegrator(lightColorIntegrators);
+        var mod = fxModifiers[i];
+        if (mod is EffectFloatModifier)
+          mod.CreateOrAttachToIntegrator(floatIntegrators);
+        else if (mod is EffectColorModifier)
+          mod.CreateOrAttachToIntegrator(colorIntegrators);
+        else if (mod is EffectPositionModifier)
+          mod.CreateOrAttachToIntegrator(positionIntegrators);
+        else if (mod is EffectRotationModifier)
+          mod.CreateOrAttachToIntegrator(rotationIntegrators);
+        else if (mod is EffectScaleModifier)
+          mod.CreateOrAttachToIntegrator(scaleIntegrators);
+        else if (mod is EffectLightFloatModifier)
+          mod.CreateOrAttachToIntegrator(lightFloatIntegrators);
+        else if (mod is EffectLightColorModifier)
+          mod.CreateOrAttachToIntegrator(lightColorIntegrators);
       }
     }
 
@@ -313,21 +334,58 @@ namespace Waterfall
       if (effectVisible)
       {
         s_fxApply.Begin();
-        foreach (var fx in fxModifiers)
+        for (int i = 0; i < fxModifiers.Count; i++)
         {
+          var     fx             = fxModifiers[i];
           float[] controllerData = fx.Controller == null ? EmptyControllerValues : fx.Controller.Get();
           fx.Apply(controllerData);
         }
+
         s_fxApply.End();
 
         s_Integrators.Begin();
-        foreach (var integrator in floatIntegrators) integrator.Update();
-        foreach (var integrator in colorIntegrators) integrator.Update();
-        foreach (var integrator in positionIntegrators) integrator.Update();
-        foreach (var integrator in scaleIntegrators) integrator.Update();
-        foreach (var integrator in rotationIntegrators) integrator.Update();
-        foreach (var integrator in lightFloatIntegrators) integrator.Update();
-        foreach (var integrator in lightColorIntegrators) integrator.Update();
+        for (int i = 0; i < floatIntegrators.Count; i++)
+        {
+          var integrator = floatIntegrators[i];
+          integrator.Update();
+        }
+
+        for (int i = 0; i < colorIntegrators.Count; i++)
+        {
+          var integrator = colorIntegrators[i];
+          integrator.Update();
+        }
+
+        for (int i = 0; i < positionIntegrators.Count; i++)
+        {
+          var integrator = positionIntegrators[i];
+          integrator.Update();
+        }
+
+        for (int i = 0; i < scaleIntegrators.Count; i++)
+        {
+          var integrator = scaleIntegrators[i];
+          integrator.Update();
+        }
+
+        for (int i = 0; i < rotationIntegrators.Count; i++)
+        {
+          var integrator = rotationIntegrators[i];
+          integrator.Update();
+        }
+
+        for (int i = 0; i < lightFloatIntegrators.Count; i++)
+        {
+          var integrator = lightFloatIntegrators[i];
+          integrator.Update();
+        }
+
+        for (int i = 0; i < lightColorIntegrators.Count; i++)
+        {
+          var integrator = lightColorIntegrators[i];
+          integrator.Update();
+        }
+
         s_Integrators.End();
       }
       s_Update.End();
@@ -338,9 +396,11 @@ namespace Waterfall
     {
       camerasProf.Begin();
       var c = camera.transform;
-      foreach (var renderer in renderers)
+      for (int i = 0; i < renderers.Count; i++)
       {
-        if (!renderer.enabled) continue;
+        var renderer = renderers[i];
+        if (!renderer.enabled)
+          continue;
         Material mat = renderer.material;
 
         int qDelta;
@@ -348,14 +408,16 @@ namespace Waterfall
           qDelta = Settings.DistortQueue;
         else
         {
-          float camDistBounds = Vector3.Dot(renderer.bounds.center - c.position, c.forward);
+          float camDistBounds    = Vector3.Dot(renderer.bounds.center      - c.position, c.forward);
           float camDistTransform = Vector3.Dot(renderer.transform.position - c.position, c.forward);
-          qDelta = Settings.QueueDepth - (int)Mathf.Clamp(Mathf.Min(camDistBounds, camDistTransform) / Settings.SortedDepth * Settings.QueueDepth, 0, Settings.QueueDepth);
+          qDelta = Settings.QueueDepth - (int) Mathf.Clamp(Mathf.Min(camDistBounds, camDistTransform) / Settings.SortedDepth * Settings.QueueDepth, 0, Settings.QueueDepth);
         }
+
         if (mat.HasProperty("_Intensity"))
           qDelta += 1;
         mat.renderQueue = Settings.TransparentQueueBase + qDelta;
       }
+
       camerasProf.End();
     }
 
@@ -363,12 +425,13 @@ namespace Waterfall
     {
       float destMode = Settings.EnableLegacyBlendModes ? 6 : 1;
 
-      foreach (var mat in effectRendererMaterials)
+      for (int i = 0; i < effectRendererMaterials.Count; i++)
       {
+        var mat = effectRendererMaterials[i];
         if (mat.HasProperty("_DestMode"))
         {
-          mat.SetFloat("_DestMode", isHDR ? 1 : destMode);
-          mat.SetFloat("_ClipBrightness", isHDR ? 50: 1);
+          mat.SetFloat("_DestMode",       isHDR ? 1 : destMode);
+          mat.SetFloat("_ClipBrightness", isHDR ? 50 : 1);
         }
       }
     }
@@ -425,15 +488,18 @@ namespace Waterfall
         effectTransforms[i].localScale = state ? Vector3.Scale(baseScales[i], TemplateScaleOffset) : Vector3.one * 0.00001f;
       effectVisible = state;
 
-      foreach (var r in effectRenderers)
+      for (int i = 0; i < effectRenderers.Count; i++)
       {
+        var r = effectRenderers[i];
         r.enabled = state;
       }
 
-      foreach (var waterfallLight in model.lights)
+      for (int i = 0; i < model.lights.Count; i++)
       {
-        foreach (var light in waterfallLight.lights)
+        var waterfallLight = model.lights[i];
+        for (int j = 0; j < waterfallLight.lights.Count; j++)
         {
+          var light = waterfallLight.lights[j];
           light.enabled = state;
         }
       }

--- a/Source/Waterfall/Effects/WaterfallEffectTemplate.cs
+++ b/Source/Waterfall/Effects/WaterfallEffectTemplate.cs
@@ -34,8 +34,11 @@ namespace Waterfall
 
       template = WaterfallTemplates.GetTemplate(templateName);
       allFX.Clear();
-      foreach (var fx in template.allFX)
+      for (int i = 0; i < template.allFX.Count; i++)
+      {
+        var fx = template.allFX[i];
         allFX.Add(new(fx, this));
+      }
     }
 
     public ConfigNode Save()

--- a/Source/Waterfall/Effects/WaterfallLight.cs
+++ b/Source/Waterfall/Effects/WaterfallLight.cs
@@ -51,8 +51,9 @@ namespace Waterfall
       if (baseTransformName != "")
       {
         var candidates = parentTransform.GetComponentsInChildren<Transform>();
-        foreach (var t in candidates)
+        for (int i = 0; i < candidates.Length; i++)
         {
+          var t = candidates[i];
           var l = t.GetComponent<Light>();
           if (l != null)
           {
@@ -72,8 +73,9 @@ namespace Waterfall
 
       Utils.Log($"[WaterfallLight]: Initialized WaterfallLight at {parentTransform}, {lights.Count} Count", LogType.Effects);
 
-      foreach (var l in lights)
+      for (int i = 0; i < lights.Count; i++)
       {
+        var l = lights[i];
         l.range     = range;
         l.type      = lightType;
         l.intensity = intensity;
@@ -85,8 +87,9 @@ namespace Waterfall
     public void SetRange(float value)
     {
       range = value;
-      foreach (var l in lights)
+      for (int i = 0; i < lights.Count; i++)
       {
+        var l = lights[i];
         l.range = range;
       }
     }
@@ -94,8 +97,9 @@ namespace Waterfall
     public void SetAngle(float value)
     {
       angle = value;
-      foreach (var l in lights)
+      for (int i = 0; i < lights.Count; i++)
       {
+        var l = lights[i];
         l.spotAngle = angle;
       }
     }
@@ -103,8 +107,9 @@ namespace Waterfall
     public void SetIntensity(float value)
     {
       intensity = value;
-      foreach (var l in lights)
+      for (int i = 0; i < lights.Count; i++)
       {
+        var l = lights[i];
         l.intensity = intensity;
       }
     }
@@ -112,8 +117,9 @@ namespace Waterfall
     public void SetColor(Color value)
     {
       color = value;
-      foreach (var l in lights)
+      for (int i = 0; i < lights.Count; i++)
       {
+        var l = lights[i];
         l.color = color;
       }
     }
@@ -121,8 +127,9 @@ namespace Waterfall
     public void SetLightType(LightType lType)
     {
       lightType = lType;
-      foreach (var l in lights)
+      for (int i = 0; i < lights.Count; i++)
       {
+        var l = lights[i];
         l.type = lightType;
       }
     }

--- a/Source/Waterfall/Effects/WaterfallMaterial.cs
+++ b/Source/Waterfall/Effects/WaterfallMaterial.cs
@@ -68,18 +68,24 @@ namespace Waterfall
       Utils.Log(String.Format("[WaterfallMaterial]: Loading new material for {0} ", transformName), LogType.Effects);
 
       matProperties = new();
-      foreach (var subnode in node.GetNodes(WaterfallConstants.TextureNodeName))
+      var nodes = node.GetNodes(WaterfallConstants.TextureNodeName);
+      for (int i = 0; i < nodes.Length; i++)
       {
+        var subnode = nodes[i];
         matProperties.Add(new WaterfallMaterialTextureProperty(subnode));
       }
 
-      foreach (var subnode in node.GetNodes(WaterfallConstants.ColorNodeName))
+      var subnodes = node.GetNodes(WaterfallConstants.ColorNodeName);
+      for (int i = 0; i < subnodes.Length; i++)
       {
+        var subnode = subnodes[i];
         matProperties.Add(new WaterfallMaterialColorProperty(subnode));
       }
 
-      foreach (var subnode in node.GetNodes(WaterfallConstants.FloatNodeName))
+      var configNodes = node.GetNodes(WaterfallConstants.FloatNodeName);
+      for (int i = 0; i < configNodes.Length; i++)
       {
+        var subnode = configNodes[i];
         matProperties.Add(new WaterfallMaterialFloatProperty(subnode));
       }
     }
@@ -177,8 +183,9 @@ namespace Waterfall
     {
       if (skinnedMeshes != null)
       {
-        foreach (var smr in skinnedMeshes)
+        for (int i = 0; i < skinnedMeshes.Count; i++)
         {
+          var smr = skinnedMeshes[i];
           smr.Recalculate();
         }
       }
@@ -204,8 +211,9 @@ namespace Waterfall
         matProperties.Add(newProp);
       }
 
-      foreach (var mat in materials)
+      for (int i = 0; i < materials.Count; i++)
       {
+        var mat = materials[i];
         if (propertyName == "_Seed" && useAutoRandomization) { }
         else
         {
@@ -234,8 +242,9 @@ namespace Waterfall
         matProperties.Add(newProp);
       }
 
-      foreach (var mat in materials)
+      for (int i = 0; i < materials.Count; i++)
       {
+        var mat = materials[i];
         mat.SetFloatArray(propertyName, new[] { value.x, value.y, value.z, value.w });
       }
     }
@@ -262,8 +271,9 @@ namespace Waterfall
         matProperties.Add(newProp);
       }
 
-      foreach (var mat in materials)
+      for (int i = 0; i < materials.Count; i++)
       {
+        var mat = materials[i];
         mat.SetTextureScale(propertyName, value);
       }
     }
@@ -291,8 +301,9 @@ namespace Waterfall
         matProperties.Add(newProp);
       }
 
-      foreach (var mat in materials)
+      for (int i = 0; i < materials.Count; i++)
       {
+        var mat = materials[i];
         Utils.Log($"[WaterfallMaterial] Changing {propertyName} to {value} on {mat}", LogType.Effects);
         mat.SetTexture(propertyName, GameDatabase.Instance.GetTexture(value, false));
       }
@@ -319,8 +330,9 @@ namespace Waterfall
         matProperties.Add(newProp);
       }
 
-      foreach (var mat in materials)
+      for (int i = 0; i < materials.Count; i++)
       {
+        var mat = materials[i];
         mat.SetTextureOffset(propertyName, value);
       }
     }
@@ -345,8 +357,9 @@ namespace Waterfall
         matProperties.Add(newProp);
       }
 
-      foreach (var mat in materials)
+      for (int i = 0; i < materials.Count; i++)
       {
+        var mat = materials[i];
         mat.SetColor(propertyName, value);
       }
     }

--- a/Source/Waterfall/Effects/WaterfallModel.cs
+++ b/Source/Waterfall/Effects/WaterfallModel.cs
@@ -164,8 +164,9 @@ namespace Waterfall
 
     public void Update()
     {
-      foreach (var m in materials)
+      for (int i = 0; i < materials.Count; i++)
       {
+        var m = materials[i];
         m.Update();
       }
     }
@@ -182,8 +183,9 @@ namespace Waterfall
       rotationOffestString = $"{rotation.x}, {rotation.y}, {rotation.z}";
       scaleOffsetString    = $"{scale.x}, {scale.y}, {scale.z}";
 
-      foreach (var modelTransform in modelTransforms)
+      for (int i = 0; i < modelTransforms.Count; i++)
       {
+        var modelTransform = modelTransforms[i];
         modelTransform.localPosition = modelPositionOffset;
         modelTransform.localScale    = modelScaleOffset;
 
@@ -200,11 +202,13 @@ namespace Waterfall
 
     public void SetEnabled(bool state)
     {
-      foreach (var modelTransform in modelTransforms)
+      for (int i = 0; i < modelTransforms.Count; i++)
       {
-        var skinRenderers = modelTransform.GetComponentsInChildren<SkinnedMeshRenderer>();
-        foreach (var renderer in skinRenderers)
+        var modelTransform = modelTransforms[i];
+        var skinRenderers  = modelTransform.GetComponentsInChildren<SkinnedMeshRenderer>();
+        for (int j = 0; j < skinRenderers.Length; j++)
         {
+          var renderer = skinRenderers[j];
           renderer.enabled = state;
         }
 
@@ -214,20 +218,24 @@ namespace Waterfall
 
     public void SetTexture(WaterfallMaterial targetMat, string propertyName, string value)
     {
-      foreach (var m in materials)
+      for (int i = 0; i < materials.Count; i++)
       {
+        var m = materials[i];
         if (m == targetMat)
         {
           m.SetTexture(propertyName, value);
           if (modelTransforms.Count > 1)
           {
-            foreach (var t in modelTransforms)
+            for (int transformIndex = 0; transformIndex < modelTransforms.Count; transformIndex++)
             {
-              foreach (var r in t.GetComponentsInChildren<Renderer>())
+              var t  = modelTransforms[transformIndex];
+              var renderers = t.GetComponentsInChildren<Renderer>();
+              for (int rendererIndex = 0; rendererIndex < renderers.Length; rendererIndex++)
               {
-                if (r.name == m.transformName)
+                var renderer = renderers[rendererIndex];
+                if (renderer.name == m.transformName)
                 {
-                  r.material.SetTexture(propertyName, GameDatabase.Instance.GetTexture(value, false));
+                  renderer.material.SetTexture(propertyName, GameDatabase.Instance.GetTexture(value, false));
                 }
               }
             }
@@ -238,17 +246,21 @@ namespace Waterfall
 
     public void SetFloat(WaterfallMaterial targetMat, string propertyName, float value)
     {
-      foreach (var m in materials)
+      for (int matIndex = 0; matIndex < materials.Count; matIndex++)
       {
+        var m = materials[matIndex];
         if (m == targetMat)
         {
           m.SetFloat(propertyName, value);
 
           if (modelTransforms.Count > 1)
-            foreach (var t in modelTransforms)
+            for (int transformIndex = 0; transformIndex < modelTransforms.Count; transformIndex++)
             {
-              foreach (var r in t.GetComponentsInChildren<Renderer>())
+              var t  = modelTransforms[transformIndex];
+              var rs = t.GetComponentsInChildren<Renderer>();
+              for (int rendererIndex = 0; rendererIndex < rs.Length; rendererIndex++)
               {
+                var r = rs[rendererIndex];
                 if (r.name == m.transformName)
                 {
                   if (propertyName == "_Seed" && m.useAutoRandomization) { }
@@ -265,16 +277,20 @@ namespace Waterfall
 
     public void SetVector4(WaterfallMaterial targetMat, string propertyName, Vector4 value)
     {
-      foreach (var m in materials)
+      for (int matIndex = 0; matIndex < materials.Count; matIndex++)
       {
+        var m = materials[matIndex];
         if (m == targetMat)
         {
           m.SetVector4(propertyName, value);
           if (modelTransforms.Count > 1)
-            foreach (var t in modelTransforms)
+            for (int transformIndex = 0; transformIndex < modelTransforms.Count; transformIndex++)
             {
-              foreach (var r in t.GetComponentsInChildren<Renderer>())
+              var t  = modelTransforms[transformIndex];
+              var rs = t.GetComponentsInChildren<Renderer>();
+              for (int rendererIndex = 0; rendererIndex < rs.Length; rendererIndex++)
               {
+                var r = rs[rendererIndex];
                 if (r.name == m.transformName)
                 {
                   r.material.SetVector(propertyName, value);
@@ -287,16 +303,20 @@ namespace Waterfall
 
     public void SetTextureScale(WaterfallMaterial targetMat, string propertyName, Vector2 value)
     {
-      foreach (var m in materials)
+      for (int matIndex = 0; matIndex < materials.Count; matIndex++)
       {
+        var m = materials[matIndex];
         if (m == targetMat)
         {
           m.SetTextureScale(propertyName, value);
           if (modelTransforms.Count > 1)
-            foreach (var t in modelTransforms)
+            for (int transformIndex = 0; transformIndex < modelTransforms.Count; transformIndex++)
             {
-              foreach (var r in t.GetComponentsInChildren<Renderer>())
+              var t  = modelTransforms[transformIndex];
+              var rs = t.GetComponentsInChildren<Renderer>();
+              for (int rendererIndex = 0; rendererIndex < rs.Length; rendererIndex++)
               {
+                var r = rs[rendererIndex];
                 if (r.name == m.transformName)
                 {
                   r.material.SetTextureScale(propertyName, value);
@@ -309,16 +329,20 @@ namespace Waterfall
 
     public void SetTextureOffset(WaterfallMaterial targetMat, string propertyName, Vector2 value)
     {
-      foreach (var m in materials)
+      for (int maxIndex = 0; maxIndex < materials.Count; maxIndex++)
       {
+        var m = materials[maxIndex];
         if (m == targetMat)
         {
           m.SetTextureOffset(propertyName, value);
           if (modelTransforms.Count > 1)
-            foreach (var t in modelTransforms)
+            for (int transformIndex = 0; transformIndex < modelTransforms.Count; transformIndex++)
             {
-              foreach (var r in t.GetComponentsInChildren<Renderer>())
+              var t  = modelTransforms[transformIndex];
+              var rs = t.GetComponentsInChildren<Renderer>();
+              for (int rendererIndex = 0; rendererIndex < rs.Length; rendererIndex++)
               {
+                var r = rs[rendererIndex];
                 if (r.name == m.transformName)
                 {
                   r.material.SetTextureOffset(propertyName, value);
@@ -331,17 +355,21 @@ namespace Waterfall
 
     public void SetColor(WaterfallMaterial targetMat, string propertyName, Color value)
     {
-      foreach (var m in materials)
+      for (int matIndex = 0; matIndex < materials.Count; matIndex++)
       {
+        var m = materials[matIndex];
         if (m == targetMat)
         {
           m.SetColor(propertyName, value);
 
           if (modelTransforms.Count > 1)
-            foreach (var t in modelTransforms)
+            for (int transformIndex = 0; transformIndex < modelTransforms.Count; transformIndex++)
             {
-              foreach (var r in t.GetComponentsInChildren<Renderer>())
+              var t  = modelTransforms[transformIndex];
+              var rs = t.GetComponentsInChildren<Renderer>();
+              for (int rendererIndex = 0; rendererIndex < rs.Length; rendererIndex++)
               {
+                var r = rs[rendererIndex];
                 if (r.name == m.transformName)
                 {
                   r.material.SetColor(propertyName, value);
@@ -354,17 +382,21 @@ namespace Waterfall
 
     public void SetLightRange(WaterfallLight targetLight, float value)
     {
-      foreach (var l in lights)
+      for (int lightIndex = 0; lightIndex < lights.Count; lightIndex++)
       {
+        var l = lights[lightIndex];
         if (l == targetLight)
         {
           l.SetRange(value);
 
           if (modelTransforms.Count > 1)
-            foreach (var t in modelTransforms)
+            for (int transformIndex = 0; transformIndex < modelTransforms.Count; transformIndex++)
             {
-              foreach (var li in t.GetComponentsInChildren<Light>())
+              var t   = modelTransforms[transformIndex];
+              var lis = t.GetComponentsInChildren<Light>();
+              for (int lightComponentIndex = 0; lightComponentIndex < lis.Length; lightComponentIndex++)
               {
+                var li = lis[lightComponentIndex];
                 li.range = value;
               }
             }
@@ -374,17 +406,21 @@ namespace Waterfall
 
     public void SetLightIntensity(WaterfallLight targetLight, float value)
     {
-      foreach (var l in lights)
+      for (int lightIndex = 0; lightIndex < lights.Count; lightIndex++)
       {
+        var l = lights[lightIndex];
         if (l == targetLight)
         {
           l.SetIntensity(value);
 
           if (modelTransforms.Count > 1)
-            foreach (var t in modelTransforms)
+            for (int transformIndex = 0; transformIndex < modelTransforms.Count; transformIndex++)
             {
-              foreach (var li in t.GetComponentsInChildren<Light>())
+              var t   = modelTransforms[transformIndex];
+              var lis = t.GetComponentsInChildren<Light>();
+              for (int lightComponentIndex = 0; lightComponentIndex < lis.Length; lightComponentIndex++)
               {
+                var li = lis[lightComponentIndex];
                 li.intensity = value;
               }
             }
@@ -394,17 +430,21 @@ namespace Waterfall
 
     public void SetLightAngle(WaterfallLight targetLight, float value)
     {
-      foreach (var l in lights)
+      for (int lightIndex = 0; lightIndex < lights.Count; lightIndex++)
       {
+        var l = lights[lightIndex];
         if (l == targetLight)
         {
           l.SetAngle(value);
 
           if (modelTransforms.Count > 1)
-            foreach (var t in modelTransforms)
+            for (int transformIndex = 0; transformIndex < modelTransforms.Count; transformIndex++)
             {
-              foreach (var li in t.GetComponentsInChildren<Light>())
+              var t   = modelTransforms[transformIndex];
+              var lis = t.GetComponentsInChildren<Light>();
+              for (int lightComponentIndex = 0; lightComponentIndex < lis.Length; lightComponentIndex++)
               {
+                var li = lis[lightComponentIndex];
                 li.spotAngle = value;
               }
             }
@@ -414,17 +454,21 @@ namespace Waterfall
 
     public void SetLightColor(WaterfallLight targetLight, Color value)
     {
-      foreach (var l in lights)
+      for (int lightIndex = 0; lightIndex < lights.Count; lightIndex++)
       {
+        var l = lights[lightIndex];
         if (l == targetLight)
         {
           l.SetColor(value);
 
           if (modelTransforms.Count > 1)
-            foreach (var t in modelTransforms)
+            for (int transformIndex = 0; transformIndex < modelTransforms.Count; transformIndex++)
             {
-              foreach (var li in t.GetComponentsInChildren<Light>())
+              var t   = modelTransforms[transformIndex];
+              var lis = t.GetComponentsInChildren<Light>();
+              for (int lightComponentIndex = 0; lightComponentIndex < lis.Length; lightComponentIndex++)
               {
+                var li = lis[lightComponentIndex];
                 li.color = value;
               }
             }
@@ -434,17 +478,21 @@ namespace Waterfall
 
     public void SetLightType(WaterfallLight targetLight, LightType value)
     {
-      foreach (var l in lights)
+      for (int lightIndex = 0; lightIndex < lights.Count; lightIndex++)
       {
+        var l = lights[lightIndex];
         if (l == targetLight)
         {
           l.SetLightType(value);
 
           if (modelTransforms.Count > 1)
-            foreach (var t in modelTransforms)
+            for (int transformIndex = 0; transformIndex < modelTransforms.Count; transformIndex++)
             {
-              foreach (var li in t.GetComponentsInChildren<Light>())
+              var t   = modelTransforms[transformIndex];
+              var lis = t.GetComponentsInChildren<Light>();
+              for (int lightComponentIndex = 0; lightComponentIndex < lis.Length; lightComponentIndex++)
               {
+                var li = lis[lightComponentIndex];
                 li.type = value;
               }
             }

--- a/Source/Waterfall/Modules/ModuleWaterfallFX.cs
+++ b/Source/Waterfall/Modules/ModuleWaterfallFX.cs
@@ -73,8 +73,11 @@ namespace Waterfall
     private void GatherRenderers()
     {
       if (allRenderers.Count == 0)
-        foreach (var fx in allFX)
+        for (int i = 0; i < allFX.Count; i++)
+        {
+          var fx = allFX[i];
           allRenderers.AddUniqueRange(fx.effectRenderers);
+        }
     }
 
     private static readonly ProfilerMarker luSetup = new ProfilerMarker("Waterfall.LateUpdate.Setup");
@@ -99,12 +102,14 @@ namespace Waterfall
         }
         luControllers.End();
         luEffects.Begin();
-        foreach (var fx in allFX)
+        for (int i = 0; i < allFX.Count; i++)
         {
+          var fx = allFX[i];
           fx.Update();
           if (changeHDR)
             fx.SetHDR(isHDR);
         }
+
         luEffects.End();
         WaterfallEffect.SetupRenderersForCamera(camera, allRenderers);
       }

--- a/Source/Waterfall/UI/GraphUtils.cs
+++ b/Source/Waterfall/UI/GraphUtils.cs
@@ -13,9 +13,10 @@ namespace Waterfall.UI
     /// <returns></returns>
     public static List<FloatString4> FloatCurveToPoints(FloatCurve inCurve)
     {
-      var outPoints = new List<FloatString4>();
-      foreach (var kf in inCurve.Curve.keys)
+      var outPoints = new List<FloatString4>(inCurve.Curve.keys.Length);
+      for (int i = 0; i < inCurve.Curve.keys.Length; i++)
       {
+        var kf = inCurve.Curve.keys[i];
         outPoints.Add(new(kf.time, kf.value, kf.inTangent, kf.outTangent));
       }
 
@@ -30,8 +31,9 @@ namespace Waterfall.UI
     public static string PointsToString(List<FloatString4> inPoints)
     {
       string buff = "";
-      foreach (var p in inPoints)
+      for (int i = 0; i < inPoints.Count; i++)
       {
+        var p = inPoints[i];
         buff += $"key = {p.floats.x} {p.floats.y} {p.floats.z} {p.floats.w}";
       }
 
@@ -48,9 +50,10 @@ namespace Waterfall.UI
       var newPoints = new List<FloatString4>();
 
       string[] lines = data.Split('\n');
-      foreach (string line in lines)
+      for (int i = 0; i < lines.Length; i++)
       {
-        string[] pcs = line.Trim().Split(new[] { '=', ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+        string   line = lines[i];
+        string[] pcs  = line.Trim().Split(new[] { '=', ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
         if (pcs.Length >= 3 && pcs[0] == "key")
         {
           var nv = new FloatString4();


### PR DESCRIPTION
This PR converts a number of (probably too many) `foreach` loops to `for` loops to improve waterfall's performance.

It really sucks that the C# compiler or Mono can't optimize the foreach loops to be efficient, but there are a number of Stack Overflow questions and other articles documenting that foreach loops, especially when in tight loops (like a game's render) create a lot of garbage and don't perform as well as for loops.

I performed two profiling runs of the game, before and after these changes. Both profile runs were for two minutes, on the launch pad (not launched) just sitting there. The ship is medium-sized, 500k funds, with maybe 20 or 25 thrusters in total? Another optimization on my mind is that we don't need to run waterfall effects for engines that haven't even started yet probably...

`foreach`:

![image](https://user-images.githubusercontent.com/342540/202930795-459ca60e-ad6d-44a0-ab2a-e09658b3e8fa.png)

`for`:

![image](https://user-images.githubusercontent.com/342540/202930814-7dddd86d-d4d8-4369-9d2c-0444de94a39f.png)

A solid reduction of 4 seconds of profiler time, over the 2 minutes profiling.

