### PR TITLE
#144: optimize SetupRenderersForCamera

### DIFF
--- a/Source/Waterfall/Effects/WaterfallEffect.cs
+++ b/Source/Waterfall/Effects/WaterfallEffect.cs
@@ -474,7 +474,7 @@ namespace Waterfall
 
         // TODO: maybe use bounds.ClosestPoint here?
         float camDistBounds = Vector3.Dot(renderer.bounds.center - cameraPosition, cameraForward);
-        float camDistTransform = Vector3.Dot(renderer.transform.position - cameraposition, cameraForward);
+        float camDistTransform = Vector3.Dot(renderer.transform.position - cameraPosition, cameraForward);
         int qDelta = Settings.QueueDepth - (int)Mathf.Clamp(Mathf.Min(camDistBounds, camDistTransform) * queueScalar, 0, Settings.QueueDepth);
 
         // TODO: not sure how much time this takes but we could cache it (or store these materials separately)

--- a/Source/Waterfall/Effects/WaterfallEffect.cs
+++ b/Source/Waterfall/Effects/WaterfallEffect.cs
@@ -477,6 +477,7 @@ namespace Waterfall
         float camDistTransform = Vector3.Dot(renderer.transform.position - cameraposition, cameraForward);
         int qDelta = Settings.QueueDepth - (int)Mathf.Clamp(Mathf.Min(camDistBounds, camDistTransform) * queueScalar, 0, Settings.QueueDepth);
 
+        // TODO: not sure how much time this takes but we could cache it (or store these materials separately)
         if (mat.HasProperty(ShaderPropertyID._Intensity))
           qDelta += 1;
         mat.renderQueue = Settings.TransparentQueueBase + qDelta;

--- a/Source/Waterfall/Effects/WaterfallEffect.cs
+++ b/Source/Waterfall/Effects/WaterfallEffect.cs
@@ -472,10 +472,10 @@ namespace Waterfall
         if (!renderer.enabled) continue;
         Material mat = renderer.material;
 
-        Vector3 closestPoint = renderer.bounds.ClosestPoint(cameraPosition);
-        Vector3 toClosestPoint = closestPoint - cameraPosition;
-        float camDist = Vector3.Dot(toClosestPoint, cameraForward);
-        int qDelta = Settings.QueueDepth - (int)Mathf.Clamp(camDist * queueScalar, 0, Settings.QueueDepth);
+        // TODO: maybe use bounds.ClosestPoint here?
+        float camDistBounds = Vector3.Dot(renderer.bounds.center - cameraPosition, cameraForward);
+        float camDistTransform = Vector3.Dot(renderer.transform.position - cameraposition, cameraForward);
+        int qDelta = Settings.QueueDepth - (int)Mathf.Clamp(Mathf.Min(camDistBounds, camDistTransform) * queueScalar, 0, Settings.QueueDepth);
 
         if (mat.HasProperty(ShaderPropertyID._Intensity))
           qDelta += 1;

--- a/Source/Waterfall/Effects/WaterfallEffect.cs
+++ b/Source/Waterfall/Effects/WaterfallEffect.cs
@@ -474,16 +474,11 @@ namespace Waterfall
         if (!renderer.enabled) continue;
         Material mat = renderer.material;
 
-        int qDelta;
-        if (mat.HasProperty(ShaderPropertyID._Strength))
-          qDelta = Settings.DistortQueue;
-        else
-        {
-          Vector3 closestPoint = renderer.bounds.ClosestPoint(cameraPosition);
-          Vector3 toClosestPoint = closestPoint - cameraPosition;
-          float camDist = Vector3.Dot(toClosestPoint, cameraForward);
-          qDelta = Settings.QueueDepth - (int)Mathf.Clamp(camDist * queueScalar, 0, Settings.QueueDepth);
-        }
+        Vector3 closestPoint = renderer.bounds.ClosestPoint(cameraPosition);
+        Vector3 toClosestPoint = closestPoint - cameraPosition;
+        float camDist = Vector3.Dot(toClosestPoint, cameraForward);
+        int qDelta = Settings.QueueDepth - (int)Mathf.Clamp(camDist * queueScalar, 0, Settings.QueueDepth);
+
         if (mat.HasProperty(ShaderPropertyID._Intensity))
           qDelta += 1;
         mat.renderQueue = Settings.TransparentQueueBase + qDelta;

--- a/Source/Waterfall/Effects/WaterfallEffect.cs
+++ b/Source/Waterfall/Effects/WaterfallEffect.cs
@@ -470,7 +470,7 @@ namespace Waterfall
         Material mat = renderer.material;
 
         int qDelta;
-        if (mat.HasProperty("_Strength"))
+        if (mat.HasProperty(ShaderPropertyID._Strength))
           qDelta = Settings.DistortQueue;
         else
         {
@@ -478,7 +478,7 @@ namespace Waterfall
           float camDistTransform = Vector3.Dot(renderer.transform.position - c.position, c.forward);
           qDelta = Settings.QueueDepth - (int)Mathf.Clamp(Mathf.Min(camDistBounds, camDistTransform) / Settings.SortedDepth * Settings.QueueDepth, 0, Settings.QueueDepth);
         }
-        if (mat.HasProperty("_Intensity"))
+        if (mat.HasProperty(ShaderPropertyID._Intensity))
           qDelta += 1;
         mat.renderQueue = Settings.TransparentQueueBase + qDelta;
       }
@@ -491,10 +491,10 @@ namespace Waterfall
 
       foreach (var mat in effectRendererMaterials)
       {
-        if (mat.HasProperty("_DestMode"))
+        if (mat.HasProperty(ShaderPropertyID._DestMode))
         {
-          mat.SetFloat("_DestMode", isHDR ? 1 : destMode);
-          mat.SetFloat("_ClipBrightness", isHDR ? 50: 1);
+          mat.SetFloat(ShaderPropertyID._DestMode, isHDR ? 1 : destMode);
+          mat.SetFloat(ShaderPropertyID._ClipBrightness, isHDR ? 50: 1);
         }
       }
     }

--- a/Source/Waterfall/Effects/WaterfallEffect.cs
+++ b/Source/Waterfall/Effects/WaterfallEffect.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using UniLinq;
 using Unity.Profiling;
 using UnityEngine;
@@ -461,7 +460,6 @@ namespace Waterfall
     }
 
     private static readonly ProfilerMarker camerasProf = new("Waterfall.Effect.Update.Cameras");
-
     public static void SetupRenderersForCamera(Camera camera, List<Renderer> renderers)
     {
       camerasProf.Begin();

--- a/Source/Waterfall/Effects/WaterfallMaterial.cs
+++ b/Source/Waterfall/Effects/WaterfallMaterial.cs
@@ -163,9 +163,9 @@ namespace Waterfall
             p.Initialize(mat);
           }
 
-          if (useAutoRandomization && mat.HasProperty("_Seed"))
+          if (useAutoRandomization && mat.HasProperty(ShaderPropertyID._Seed))
           {
-            mat.SetFloat("_Seed", Random.Range(-1f, 1f));
+            mat.SetFloat(ShaderPropertyID._Seed, Random.Range(-1f, 1f));
           }
 
           Utils.Log(String.Format("[WaterfallMaterial]: Assigned new shader {0} ", mat.shader), LogType.Effects);

--- a/Source/Waterfall/Modules/ModuleWaterfallFX.cs
+++ b/Source/Waterfall/Modules/ModuleWaterfallFX.cs
@@ -84,11 +84,11 @@ namespace Waterfall
           foreach (var renderer in fx.effectRenderers)
           {
             Material mat = renderer.material;
-            int qDelta;
+
             // distortion effects get a constant renderqueue value, so they don't need to be sorted
             if (mat.HasProperty(ShaderPropertyID._Strength))
             {
-              qDelta = Settings.DistortQueue;
+              int qDelta = Settings.DistortQueue;
               if (mat.HasProperty(ShaderPropertyID._Intensity))
                 qDelta += 1;
               mat.renderQueue = Settings.TransparentQueueBase + qDelta;

--- a/Source/Waterfall/WaterfallConstants.cs
+++ b/Source/Waterfall/WaterfallConstants.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using UnityEngine;
 
 namespace Waterfall
 {
@@ -100,5 +101,14 @@ namespace Waterfall
     
 
 
+  }
+
+  public static class ShaderPropertyID
+  {
+    public static readonly int _Strength = Shader.PropertyToID(nameof(_Strength));
+    public static readonly int _Intensity = Shader.PropertyToID(nameof(_Intensity));
+    public static readonly int _DestMode = Shader.PropertyToID(nameof(_DestMode));
+    public static readonly int _ClipBrightness = Shader.PropertyToID(nameof(_ClipBrightness));
+    public static readonly int _Seed = Shader.PropertyToID(nameof(_Seed));
   }
 }


### PR DESCRIPTION
-use property IDs instead of strings
-don't track distortion renderers since their renderqueue value never changes
-pull expensive stuff out of the loop
-use Bounds.ClosestPoint instead of two dot products.  Seems like it should be more correct and same or better performance