### PR TITLE
Fix #150: UI clickthrough and lifecycle issues

### DIFF
--- a/Source/Waterfall/Settings.cs
+++ b/Source/Waterfall/Settings.cs
@@ -2,22 +2,6 @@
 
 namespace Waterfall
 {
-  [KSPAddon(KSPAddon.Startup.EveryScene, false)]
-  public class Waterfall : MonoBehaviour
-  {
-    public static Waterfall Instance { get; private set; }
-
-    protected void Awake()
-    {
-      Instance = this;
-    }
-
-    protected void Start()
-    {
-      WaterfallAssets.Load();
-    }
-  }
-
   /// <summary>
   ///   Static class to hold settings and configuration
   /// </summary>

--- a/Source/Waterfall/UI/UIAppToolbarWindow.cs
+++ b/Source/Waterfall/UI/UIAppToolbarWindow.cs
@@ -1,31 +1,38 @@
 ﻿using KSP.UI.Screens;
+using UnityEngine;
 
 namespace Waterfall.UI
 {
-  public class UIAppToolbarWindow : UIBaseWindow
+  [KSPAddon(KSPAddon.Startup.Flight, false)]
+  public class UIAppToolbarWindow : MonoBehaviour
   {
     // Stock toolbar button
-    protected static ApplicationLauncherButton stockToolbarButton;
+    protected ApplicationLauncherButton stockToolbarButton;
+    private Texture2D activeTexture;
+    private Texture2D inactiveTexture;
 
-    protected override void Awake()
+    private WaterfallUI waterfallUI;
+
+    void Awake()
     {
-      base.Awake();
       if (Settings.ShowEffectEditor)
       {
         GameEvents.onGUIApplicationLauncherReady.Add(OnGUIAppLauncherReady);
         GameEvents.onGUIApplicationLauncherDestroyed.Add(OnGUIAppLauncherDestroyed);
+
+        activeTexture = GameDatabase.Instance.GetTexture(UIConstants.UIApplicationButton_On, false);
+        inactiveTexture = GameDatabase.Instance.GetTexture(UIConstants.UIApplicationButton_Off, false);
+
+        waterfallUI = new GameObject(nameof(WaterfallUI)).AddComponent<WaterfallUI>();
+      }
+      else
+      {
+        GameObject.Destroy(gameObject);
       }
     }
 
-    protected override void Start()
-    {
-      base.Start();
-      if (Settings.ShowEffectEditor && ApplicationLauncher.Ready)
-        OnGUIAppLauncherReady();
-    }
-
     // Stock toolbar handling methods
-    public void OnDestroy()
+    void OnDestroy()
     {
       if (Settings.DebugUIMode)
         Utils.Log("[UI]: OnDestroy Fired");
@@ -36,14 +43,18 @@ namespace Waterfall.UI
       {
         ApplicationLauncher.Instance.RemoveModApplication(stockToolbarButton);
       }
-    }
 
+      if (waterfallUI != null)
+      {
+        GameObject.Destroy(waterfallUI.gameObject.gameObject);
+      }
+    }
     protected void OnToolbarButtonToggle()
     {
       if (Settings.DebugUIMode)
         Utils.Log("[UI]: Toolbar Button Toggled");
-      ToggleWindow();
-      stockToolbarButton.SetTexture(GameDatabase.Instance.GetTexture(showWindow ? UIConstants.UIApplicationButton_On : UIConstants.UIApplicationButton_Off, false));
+      UIBaseWindow.ToggleWindow();
+      stockToolbarButton.SetTexture(UIBaseWindow.showWindow ? activeTexture : inactiveTexture);
     }
 
 
@@ -61,7 +72,7 @@ namespace Waterfall.UI
                                                                             DummyVoid,
                                                                             DummyVoid,
                                                                             ApplicationLauncher.AppScenes.VAB | ApplicationLauncher.AppScenes.SPH | ApplicationLauncher.AppScenes.FLIGHT,
-                                                                            GameDatabase.Instance.GetTexture(UIConstants.UIApplicationButton_Off, false));
+                                                                            inactiveTexture);
       }
     }
 
@@ -80,7 +91,7 @@ namespace Waterfall.UI
     {
       if (Settings.DebugUIMode)
         Utils.Log("[UI]: App Launcher Toggle Off");
-      stockToolbarButton.SetTexture(GameDatabase.Instance.GetTexture(UIConstants.UIApplicationButton_Off, false));
+      stockToolbarButton.SetTexture(inactiveTexture);
     }
 
     protected void DummyVoid() { }

--- a/Source/Waterfall/UI/UIBaseWindow.cs
+++ b/Source/Waterfall/UI/UIBaseWindow.cs
@@ -6,7 +6,7 @@ namespace Waterfall.UI
   public class UIBaseWindow : MonoBehaviour
   {
     // Control Vars
-    protected static bool showWindow;
+    public static bool showWindow;
     public           Rect windowPos = new(200f, 200f, 1000f, 400f);
     protected        bool initUI;
 

--- a/Source/Waterfall/UI/UIBaseWindow.cs
+++ b/Source/Waterfall/UI/UIBaseWindow.cs
@@ -15,6 +15,7 @@ namespace Waterfall.UI
     private   Vector2     scrollPosition = Vector2.zero;
     protected int         windowID       = new Random(13123).Next();
 
+    UnityEngine.UI.Image image;
 
     public Rect WindowPosition
     {
@@ -30,9 +31,9 @@ namespace Waterfall.UI
       gameObject.layer = 5;
       gameObject.AddComponent<RectTransform>();
 
-			var canvasRenderer = gameObject.AddComponent<CanvasRenderer>();
+      var canvasRenderer = gameObject.AddComponent<CanvasRenderer>();
       canvasRenderer.cullTransparentMesh = true;
-      var image = gameObject.AddComponent<UnityEngine.UI.Image>();
+      image = gameObject.AddComponent<UnityEngine.UI.Image>();
       image.color = new Color(0, 0, 0, 0);
       image.raycastTarget = true;
 
@@ -60,6 +61,8 @@ namespace Waterfall.UI
       var rectTransform = transform as RectTransform;
       rectTransform.anchoredPosition = new Vector2(windowPos.x, Screen.height - windowPos.y - windowPos.height);
       rectTransform.sizeDelta = new Vector2(windowPos.width, windowPos.height);
+
+      image.enabled = showWindow;
     }
 
     /// <summary>

--- a/Source/Waterfall/UI/WaterfallEditorUI.cs
+++ b/Source/Waterfall/UI/WaterfallEditorUI.cs
@@ -7,8 +7,7 @@ using Waterfall.UI.EffectControllersUI;
 
 namespace Waterfall.UI
 {
-  [KSPAddon(KSPAddon.Startup.Flight, false)]
-  public class WaterfallUI : UIAppToolbarWindow
+  public class WaterfallUI : UIBaseWindow
   {
     protected List<UIModifierWindow> editWindows = new();
     protected bool exportsOpen;

--- a/Source/Waterfall/WaterfallData.cs
+++ b/Source/Waterfall/WaterfallData.cs
@@ -20,6 +20,7 @@ namespace Waterfall
     public static void ModuleManagerPostLoad()
     {
       Settings.Load();
+      WaterfallAssets.Load();
       WaterfallParticleLoader.LoadParticles();
       WaterfallParticleLoader.LoadParticleProperties();
       ShaderLoader.LoadShaders();


### PR DESCRIPTION
Really two separate issues:

-hiding the window just stopped calling the ImGUI stuff, the invisible image was still there
-since the window was now attached to the MainCanvas, it wasn't being destroyed on scene changes

This PR removes the UIAppToolbarWIndow class from the Window class hierarchy and puts the Addon lifecycle stuff in there.  This was the most surgical change to fix the issues, but it does mean that it would be difficult to make another window that has a toolbar button.  If we need to do that, then the KSPAddon logic should be moved to a new class and the UIAppToolbarWindow could become an actual window again.  Note that window visibility is currently controlled by static bool UIBaseWindow.showWindow, so that would need to change too.

As a bonus, I was poking around at usages of KSPAddon and saw that the Waterfall addon that calls WaterfallAssets.Load() was probably not in the right place (would this have been running on every scene change?), so that's gone now too.