### PR TITLE
Fix #151: exception spew when a template is missing

### DIFF
--- a/Source/Waterfall/Effects/WaterfallEffectTemplate.cs
+++ b/Source/Waterfall/Effects/WaterfallEffectTemplate.cs
@@ -34,6 +34,9 @@ namespace Waterfall
 
       template = WaterfallTemplates.GetTemplate(templateName);
       allFX.Clear();
+
+      if (template == null) return;
+
       foreach (var fx in template.allFX)
         allFX.Add(new(fx, this));
     }

--- a/Source/Waterfall/WaterfallParticles.cs
+++ b/Source/Waterfall/WaterfallParticles.cs
@@ -64,6 +64,7 @@ namespace Waterfall
     {
       Utils.Log($"[Particles]: Loading {Path.GetFileNameWithoutExtension(bundlePath)}", LogType.Loading);
       var bundle = AssetBundle.LoadFromFile(bundlePath);
+      if (bundle == null) return;
       var systems = bundle.LoadAllAssets<GameObject>();
 
       foreach (var sys in systems)

--- a/Source/Waterfall/WaterfallShaders.cs
+++ b/Source/Waterfall/WaterfallShaders.cs
@@ -85,6 +85,7 @@ namespace Waterfall
     {
       Utils.Log($"[Shaders]: Loading shaders from {Path.GetFileNameWithoutExtension(bundlePath)}", LogType.Loading);
       var bundle = AssetBundle.LoadFromFile(bundlePath);
+      if (bundle == null) return;
       var shaders = bundle.LoadAllAssets<Shader>();
       foreach (var shader in shaders)
       {


### PR DESCRIPTION
-also guard against failing to load an assetbundle