### PR TITLE
Performance: modifiers can cache their values to avoid curve evaluation if the controller input didn't change

### DIFF
--- a/Source/Waterfall/EffectControllers/AtmosphereDensityController.cs
+++ b/Source/Waterfall/EffectControllers/AtmosphereDensityController.cs
@@ -19,11 +19,10 @@ namespace Waterfall
       values = new float[1];
     }
 
-    protected override bool UpdateInternal()
+    protected override float UpdateSingleValue()
     {
       //(float)parentModule.vessel.mainBody.GetPressureAtm(parentModule.vessel.altitude) 
-      values[0] = Mathf.Pow((float)parentModule.part.atmDensity, Settings.AtmosphereDensityExponent);
-      return false;
+      return Mathf.Pow((float)parentModule.part.atmDensity, Settings.AtmosphereDensityExponent);
     }
   }
 }

--- a/Source/Waterfall/EffectControllers/CustomPullController.cs
+++ b/Source/Waterfall/EffectControllers/CustomPullController.cs
@@ -85,7 +85,7 @@ namespace Waterfall
       return () => 0;
     }
 
-    protected override bool UpdateInternal()
+    protected override float UpdateSingleValue()
     {
       float newValue = Mathf.InverseLerp(minInputValue, maxInputValue, GetValue());
       float responseRate = newValue > currentValue
@@ -95,9 +95,8 @@ namespace Waterfall
       currentValue = responseRate > 0
         ? Mathf.MoveTowards(currentValue, newValue, responseRate * TimeWarp.deltaTime)
         : newValue;
-      values[0] = currentValue;
 
-      return currentValue != 0f;
+      return currentValue;
     }
 
     private float GetValue()

--- a/Source/Waterfall/EffectControllers/EngineEventController.cs
+++ b/Source/Waterfall/EffectControllers/EngineEventController.cs
@@ -70,14 +70,12 @@ namespace Waterfall
       }
     }
 
-    protected override bool UpdateInternal()
+    protected override float UpdateSingleValue()
     {
-      values[0] = 0;
       if (engineModule != null && getEngineStateFunc != null)
-        values[0] = eventCurve.Evaluate(CheckStateChange());
-      //Utils.Log($"{eventName} =>_ Ready: {eventReady}, prestate {enginePreState}, time {eventTime}, playing {eventPlaying}");
+        return eventCurve.Evaluate(CheckStateChange());
 
-      return values[0] > 0;
+      return 0;
     }
 
     public float CheckStateChange()

--- a/Source/Waterfall/EffectControllers/GimbalController.cs
+++ b/Source/Waterfall/EffectControllers/GimbalController.cs
@@ -22,16 +22,16 @@ namespace Waterfall
         Utils.LogError("[GimbalController] Could not find gimbal controller on Initialize");
     }
 
-    protected override bool UpdateInternal()
+    protected override float UpdateSingleValue()
     {
       if (gimbalController != null)
       {
-        if (axis == "x") values[0] = gimbalController.actuationLocal.x / gimbalController.gimbalRangeXP;
-        else if (axis == "y") values[0] = gimbalController.actuationLocal.y / gimbalController.gimbalRangeYP;
-        else if (axis == "z") values[0] = gimbalController.actuationLocal.z;
+        if (axis == "x") return gimbalController.actuationLocal.x / gimbalController.gimbalRangeXP;
+        else if (axis == "y") return gimbalController.actuationLocal.y / gimbalController.gimbalRangeYP;
+        else if (axis == "z") return gimbalController.actuationLocal.z;
       }
 
-      return false;
+      return 0;
     }
   }
 }

--- a/Source/Waterfall/EffectControllers/LightController.cs
+++ b/Source/Waterfall/EffectControllers/LightController.cs
@@ -33,16 +33,14 @@ namespace Waterfall
         Utils.LogError("[LightController] Could not find any lights on Initialize");
     }
 
-    protected override bool UpdateInternal()
+    protected override float UpdateSingleValue()
     {
-      bool awake = false;
       if (lightController != null)
       {
-        values[0] = lightController.intensity;
-        awake = values[0] > 0;
+        return lightController.intensity;
       }
 
-      return awake;
+      return 0;
     }
   }
 }

--- a/Source/Waterfall/EffectControllers/MachController.cs
+++ b/Source/Waterfall/EffectControllers/MachController.cs
@@ -18,10 +18,9 @@ namespace Waterfall
       values = new float[1];
     }
 
-    protected override bool UpdateInternal()
+    protected override float UpdateSingleValue()
     {
-      values[0] = (float) parentModule.vessel.mach;
-      return false;
+      return (float) parentModule.vessel.mach;
     }
   }
 }

--- a/Source/Waterfall/EffectControllers/RandomnessController.cs
+++ b/Source/Waterfall/EffectControllers/RandomnessController.cs
@@ -61,10 +61,9 @@ namespace Waterfall
 
     public float PerlinNoise() => Mathf.PerlinNoise(seed + Time.time * speed, seed + Time.time * speed) * (scale - minimum) + minimum;
 
-    protected override bool UpdateInternal()
+    protected override float UpdateSingleValue()
     {
-      values[0] = noiseFunc();
-      return false;
+      return noiseFunc();
     }
   }
 }

--- a/Source/Waterfall/EffectControllers/RandomnessController.cs
+++ b/Source/Waterfall/EffectControllers/RandomnessController.cs
@@ -61,9 +61,13 @@ namespace Waterfall
 
     public float PerlinNoise() => Mathf.PerlinNoise(seed + Time.time * speed, seed + Time.time * speed) * (scale - minimum) + minimum;
 
-    protected override float UpdateSingleValue()
+    protected override bool UpdateInternal()
     {
-      return noiseFunc();
+      // this isn't really correct; we should probably use the normal "changed" logic here - but the way things are currently set up, marking these as awake is really bad for performance
+      // I think randomness is currently kind of broken anyway, it needs another pass since it's kind of a special case in the fixed-function pipeline
+      // But if someone hooked a random controller directly up to a modifier then it wouldn't update properly.
+      values[0] = noiseFunc();
+      return false;
     }
   }
 }

--- a/Source/Waterfall/EffectControllers/ThrottleController.cs
+++ b/Source/Waterfall/EffectControllers/ThrottleController.cs
@@ -45,7 +45,7 @@ namespace Waterfall
       }
     }
 
-    protected override bool UpdateInternal()
+    protected override float UpdateSingleValue()
     {
       if (engineController == null)
       {
@@ -61,9 +61,8 @@ namespace Waterfall
           currentThrottle = Mathf.MoveTowards(currentThrottle, targetThrottle, rampRate * TimeWarp.deltaTime);
         }
       }
-      
-      values[0] = currentThrottle;
-      return currentThrottle > 0f;
+
+      return currentThrottle;
     }
 
     public override void UpgradeToCurrentVersion(Version loadedVersion)

--- a/Source/Waterfall/EffectControllers/ThrustController.cs
+++ b/Source/Waterfall/EffectControllers/ThrustController.cs
@@ -37,7 +37,7 @@ namespace Waterfall
         Utils.LogError("[ThrustController] Could not find engine controller on Initialize");
     }
 
-    protected override bool UpdateInternal()
+    protected override float UpdateSingleValue()
     {
       if (engineController == null)
       {
@@ -56,8 +56,7 @@ namespace Waterfall
                               * engineController.multIsp;
       }
 
-      values[0] = currentThrustFraction;
-      return currentThrustFraction > 0f;
+      return currentThrustFraction;
     }
   }
 }

--- a/Source/Waterfall/EffectControllers/VelocityController.cs
+++ b/Source/Waterfall/EffectControllers/VelocityController.cs
@@ -21,14 +21,14 @@ namespace Waterfall
       base.Initialize(host);
       values = new float[1];
     }
-    protected override bool UpdateInternal()
+    protected override float UpdateSingleValue()
     {
       if (mode == 0)
-        values[0] =  (float)parentModule.vessel.srf_velocity.magnitude ;
+        return (float)parentModule.vessel.srf_velocity.magnitude ;
       else
-        values[0] =  (float)parentModule.vessel.obt_velocity.magnitude ;
+        return (float)parentModule.vessel.obt_velocity.magnitude ;
 
-      return true;
+      return 0;
     }
   }
 }

--- a/Source/Waterfall/EffectControllers/WaterfallController.cs
+++ b/Source/Waterfall/EffectControllers/WaterfallController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using UnityEngine;
 using Waterfall.EffectControllers;
 
 namespace Waterfall
@@ -16,7 +17,9 @@ namespace Waterfall
     [Persistent] public string name = "unnamedController";
 
     public ModuleWaterfallFX ParentModule => parentModule;
-    public bool Sleeping { get; private set; }
+
+    public bool awake { get; protected set; }
+
     public bool overridden
     {
       get { return _overridden; }
@@ -57,7 +60,7 @@ namespace Waterfall
 
     public bool Update()
     {
-      bool awake = overridden;
+      awake = overridden;
       
       if (!overridden)
       {
@@ -67,10 +70,21 @@ namespace Waterfall
       return awake;
     }
 
+    protected virtual float UpdateSingleValue() { return values[0]; }
+
     /// <summary>
     /// Get and store the value of the controller.  Consumers should call Get() to retrieve the data.
     /// </summary>
-    protected abstract bool UpdateInternal();
+    protected virtual bool UpdateInternal()
+    {
+      float newValue = UpdateSingleValue();
+      if (Mathf.Approximately(newValue, values[0]))
+      {
+        return false;
+      }
+      values[0] = newValue;
+      return true;
+    }
 
     /// <summary>
     ///   Get the value of the controller.

--- a/Source/Waterfall/EffectModifiers/EffectModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectModifier.cs
@@ -170,6 +170,8 @@ namespace Waterfall
     public FloatCurve bCurve = new();
     public FloatCurve aCurve = new();
 
+    Color[] output;
+
     public EffectModifier_Color() : base() { }
     public EffectModifier_Color(ConfigNode node) : base(node) { }
 
@@ -194,8 +196,17 @@ namespace Waterfall
       return node;
     }
 
-    public void Get(float[] input, Color[] output)
+    public override void Init(WaterfallEffect effect)
     {
+      base.Init(effect);
+
+      output = new Color[xforms.Count];
+    }
+
+    public Color[] Get()
+    {
+      float[] input = Controller.Get();
+
       if (input.Length > 1)
       {
         for (int i = 0; i < output.Length; i++)
@@ -218,12 +229,15 @@ namespace Waterfall
         for (int i = 0; i < output.Length; i++)
           output[i] = color;
       }
+      return output;
     }
   }
+
   public abstract class EffectModifier_Vector2 : EffectModifier
   {
     public FloatCurve xCurve = new();
     public FloatCurve yCurve = new();
+    Vector2[] output;
 
     public EffectModifier_Vector2() : base() { }
     public EffectModifier_Vector2(ConfigNode node) : base(node) { }
@@ -243,8 +257,17 @@ namespace Waterfall
       node.AddNode(Utils.SerializeFloatCurve("yCurve", yCurve));
       return node;
     }
-    public void Get(float[] input, Vector2[] output)
+
+    public override void Init(WaterfallEffect effect)
     {
+      base.Init(effect);
+      output = new Vector2[xforms.Count];
+    }
+
+    public Vector2[] Get()
+    {
+      float[] input = Controller.Get();
+
       if (input.Length > 1)
       {
         for (int i = 0; i < xforms.Count; i++)
@@ -263,6 +286,7 @@ namespace Waterfall
         for (int i = 0; i < xforms.Count; i++)
           output[i] = vec;
       }
+      return output;
     }
   }
   public abstract class EffectModifier_Vector3 : EffectModifier
@@ -270,6 +294,7 @@ namespace Waterfall
     public FloatCurve xCurve = new();
     public FloatCurve yCurve = new();
     public FloatCurve zCurve = new();
+    Vector3[] output;
 
     public EffectModifier_Vector3() : base() { }
     public EffectModifier_Vector3(ConfigNode node) : base(node) { }
@@ -291,8 +316,17 @@ namespace Waterfall
       node.AddNode(Utils.SerializeFloatCurve("zCurve", zCurve));
       return node;
     }
-    public void Get(float[] input, Vector3[] output)
+
+    public override void Init(WaterfallEffect effect)
     {
+      base.Init(effect);
+      output = new Vector3[xforms.Count];
+    }
+
+    public Vector3[] Get()
+    {
+      float[] input = Controller.Get();
+
       if (input.Length > 1)
       {
         for (int i = 0; i < xforms.Count; i++)
@@ -313,12 +347,15 @@ namespace Waterfall
         for (int i = 0; i < xforms.Count; i++)
           output[i] = vec;
       }
+
+      return output;
     }
   }
 
   public abstract class EffectModifier_Float : EffectModifier
   {
     public FloatCurve curve = new();
+    float[] output;
 
     public EffectModifier_Float() : base() { }
     public EffectModifier_Float(ConfigNode node) : base(node) { }
@@ -335,8 +372,15 @@ namespace Waterfall
       return node;
     }
 
-    public void Get(float[] input, float[] output)
+    public override void Init(WaterfallEffect effect)
     {
+      base.Init(effect);
+      output = new float[xforms.Count];
+    }
+
+    public float[] Get()
+    {
+      float[] input = Controller.Get();
       if (input.Length > 1)
       {
         for (int i = 0; i < output.Length; i++)
@@ -348,6 +392,8 @@ namespace Waterfall
         for (int i = 0; i < output.Length; i++)
           output[i] = data;
       }
+
+      return output;
     }
   }
 }

--- a/Source/Waterfall/EffectModifiers/EffectModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectModifier.cs
@@ -205,29 +205,32 @@ namespace Waterfall
 
     public Color[] Get()
     {
-      float[] input = Controller.Get();
+      if (Controller.awake)
+      {
+        float[] input = Controller.Get();
 
-      if (input.Length > 1)
-      {
-        for (int i = 0; i < output.Length; i++)
+        if (input.Length > 1)
         {
-          float inValue = input[i];
-          output[i] = new(rCurve.Evaluate(inValue) + randomValue,
-                          gCurve.Evaluate(inValue) + randomValue,
-                          bCurve.Evaluate(inValue) + randomValue,
-                          aCurve.Evaluate(inValue) + randomValue);
+          for (int i = 0; i < output.Length; i++)
+          {
+            float inValue = input[i];
+            output[i] = new(rCurve.Evaluate(inValue) + randomValue,
+                            gCurve.Evaluate(inValue) + randomValue,
+                            bCurve.Evaluate(inValue) + randomValue,
+                            aCurve.Evaluate(inValue) + randomValue);
+          }
         }
-      }
-      else if (input.Length == 1)
-      {
-        float inValue = input[0];
-        Color color = new Color(
-          rCurve.Evaluate(inValue) + randomValue,
-          gCurve.Evaluate(inValue) + randomValue,
-          bCurve.Evaluate(inValue) + randomValue,
-          aCurve.Evaluate(inValue) + randomValue);
-        for (int i = 0; i < output.Length; i++)
-          output[i] = color;
+        else if (input.Length == 1)
+        {
+          float inValue = input[0];
+          Color color = new Color(
+            rCurve.Evaluate(inValue) + randomValue,
+            gCurve.Evaluate(inValue) + randomValue,
+            bCurve.Evaluate(inValue) + randomValue,
+            aCurve.Evaluate(inValue) + randomValue);
+          for (int i = 0; i < output.Length; i++)
+            output[i] = color;
+        }
       }
       return output;
     }
@@ -266,25 +269,28 @@ namespace Waterfall
 
     public Vector2[] Get()
     {
-      float[] input = Controller.Get();
+      if (Controller.awake)
+      {
+        float[] input = Controller.Get();
 
-      if (input.Length > 1)
-      {
-        for (int i = 0; i < xforms.Count; i++)
+        if (input.Length > 1)
         {
-          float inValue = input[i];
-          output[i] = new(xCurve.Evaluate(inValue) + randomValue,
-                          yCurve.Evaluate(inValue) + randomValue);
+          for (int i = 0; i < xforms.Count; i++)
+          {
+            float inValue = input[i];
+            output[i] = new(xCurve.Evaluate(inValue) + randomValue,
+                            yCurve.Evaluate(inValue) + randomValue);
+          }
         }
-      }
-      else if (input.Length == 1)
-      {
-        float inValue = input[0];
-        Vector2 vec = new(
-          xCurve.Evaluate(inValue) + randomValue,
-          yCurve.Evaluate(inValue) + randomValue);
-        for (int i = 0; i < xforms.Count; i++)
-          output[i] = vec;
+        else if (input.Length == 1)
+        {
+          float inValue = input[0];
+          Vector2 vec = new(
+            xCurve.Evaluate(inValue) + randomValue,
+            yCurve.Evaluate(inValue) + randomValue);
+          for (int i = 0; i < xforms.Count; i++)
+            output[i] = vec;
+        }
       }
       return output;
     }
@@ -325,27 +331,30 @@ namespace Waterfall
 
     public Vector3[] Get()
     {
-      float[] input = Controller.Get();
+      if (Controller.awake)
+      {
+        float[] input = Controller.Get();
 
-      if (input.Length > 1)
-      {
-        for (int i = 0; i < xforms.Count; i++)
+        if (input.Length > 1)
         {
-          float inValue = input[i];
-          output[i] = new(xCurve.Evaluate(inValue) + randomValue,
-                          yCurve.Evaluate(inValue) + randomValue,
-                          zCurve.Evaluate(inValue) + randomValue);
+          for (int i = 0; i < xforms.Count; i++)
+          {
+            float inValue = input[i];
+            output[i] = new(xCurve.Evaluate(inValue) + randomValue,
+                            yCurve.Evaluate(inValue) + randomValue,
+                            zCurve.Evaluate(inValue) + randomValue);
+          }
         }
-      }
-      else if (input.Length == 1)
-      {
-        float inValue = input[0];
-        Vector3 vec = new(
-          xCurve.Evaluate(inValue) + randomValue,
-          yCurve.Evaluate(inValue) + randomValue,
-          zCurve.Evaluate(inValue) + randomValue);
-        for (int i = 0; i < xforms.Count; i++)
-          output[i] = vec;
+        else if (input.Length == 1)
+        {
+          float inValue = input[0];
+          Vector3 vec = new(
+            xCurve.Evaluate(inValue) + randomValue,
+            yCurve.Evaluate(inValue) + randomValue,
+            zCurve.Evaluate(inValue) + randomValue);
+          for (int i = 0; i < xforms.Count; i++)
+            output[i] = vec;
+        }
       }
 
       return output;
@@ -380,17 +389,20 @@ namespace Waterfall
 
     public float[] Get()
     {
-      float[] input = Controller.Get();
-      if (input.Length > 1)
+      if (Controller.awake)
       {
-        for (int i = 0; i < output.Length; i++)
-          output[i] = curve.Evaluate(input[i]) + randomValue;
-      }
-      else if (input.Length == 1)
-      {
-        float data = curve.Evaluate(input[0]) + randomValue;
-        for (int i = 0; i < output.Length; i++)
-          output[i] = data;
+        float[] input = Controller.Get();
+        if (input.Length > 1)
+        {
+          for (int i = 0; i < output.Length; i++)
+            output[i] = curve.Evaluate(input[i]) + randomValue;
+        }
+        else if (input.Length == 1)
+        {
+          float data = curve.Evaluate(input[0]) + randomValue;
+          for (int i = 0; i < output.Length; i++)
+            output[i] = data;
+        }
       }
 
       return output;

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
@@ -280,13 +280,11 @@ namespace Waterfall
 
   public abstract class EffectIntegratorTyped<T_Value> : EffectIntegrator
   {
-    protected readonly T_Value[] modifierData;
     protected readonly T_Value[] initialValues;
     protected readonly T_Value[] workingValues;
 
     public EffectIntegratorTyped(WaterfallEffect effect, EffectModifier mod) : base(effect, mod)
     {
-      modifierData = new T_Value[xforms.Count];
       initialValues = new T_Value[xforms.Count];
       workingValues = new T_Value[xforms.Count];
     }
@@ -327,8 +325,7 @@ namespace Waterfall
       {
         if (mod.Controller != null)
         {
-          float[] controllerData = mod.Controller.Get();
-          ((EffectModifier_Float)mod).Get(controllerData, modifierData);
+          float[] modifierData = ((EffectModifier_Float)mod).Get();
           s_Integrate.Begin();
           Integrate(mod.effectMode, workingValues, modifierData);
           s_Integrate.End();
@@ -365,8 +362,7 @@ namespace Waterfall
       {
         if (mod.Controller != null)
         {
-          float[] controllerData = mod.Controller.Get();
-          ((EffectModifier_Color)mod).Get(controllerData, modifierData);
+          Color[] modifierData = ((EffectModifier_Color)mod).Get();
           s_Integrate.Begin();
           Integrate(mod.effectMode, workingValues, modifierData);
           s_Integrate.End();
@@ -400,8 +396,7 @@ namespace Waterfall
       {
         if (mod.Controller != null)
         {
-          float[] controllerData = mod.Controller.Get();
-          ((EffectModifier_Vector2)mod).Get(controllerData, modifierData);
+          Vector2[] modifierData = ((EffectModifier_Vector2)mod).Get();
           s_Integrate.Begin();
           Integrate(mod.effectMode, workingValues, modifierData);
           s_Integrate.End();
@@ -436,8 +431,7 @@ namespace Waterfall
       {
         if (mod.Controller != null)
         {
-          float[] controllerData = mod.Controller.Get();
-          ((EffectModifier_Vector3)mod).Get(controllerData, modifierData);
+          Vector3[] modifierData = ((EffectModifier_Vector3)mod).Get();
           s_Integrate.Begin();
           Integrate(mod.effectMode, workingValues, modifierData);
           s_Integrate.End();


### PR DESCRIPTION
This is slightly worse on the ground when no engines are on, but it's definitely slightly better in space.

Randomness controllers need another look since I think I might have broken them in the "DirectModifier" change.