### PR TITLE
Fix controller sleeping and a few other things

### DIFF
--- a/Source/Waterfall/EffectControllers/RCSController.cs
+++ b/Source/Waterfall/EffectControllers/RCSController.cs
@@ -60,9 +60,14 @@ namespace Waterfall
         {
           int transformIndex = activeTransformIndices[valueIndex];
           float newThrottle = rcsController.thrustForces[transformIndex] / rcsController.thrusterPower;
-          float responseRate = newThrottle > values[valueIndex] ? responseRateUp : responseRateDown;
-          values[valueIndex] = Mathf.MoveTowards(values[valueIndex], newThrottle, responseRate * TimeWarp.deltaTime);
-          awake = awake || newThrottle != 0;
+          float oldValue = values[valueIndex];
+          
+          if (!ApproximatelyEqual(oldValue, newThrottle))
+          {
+            float responseRate = newThrottle > oldValue ? responseRateUp : responseRateDown;
+            values[valueIndex] = Mathf.MoveTowards(oldValue, newThrottle, responseRate * TimeWarp.deltaTime);
+            awake = true;
+          }
         }
       }
 

--- a/Source/Waterfall/EffectControllers/WaterfallController.cs
+++ b/Source/Waterfall/EffectControllers/WaterfallController.cs
@@ -18,7 +18,7 @@ namespace Waterfall
 
     public ModuleWaterfallFX ParentModule => parentModule;
 
-    public bool awake { get; protected set; }
+    public bool awake;
 
     public bool overridden
     {
@@ -72,13 +72,18 @@ namespace Waterfall
 
     protected virtual float UpdateSingleValue() { return values[0]; }
 
+    protected static bool ApproximatelyEqual(float a, float b)
+    {
+      return Mathf.Abs(a - b) < 1e-4f;
+    }
+
     /// <summary>
     /// Get and store the value of the controller.  Consumers should call Get() to retrieve the data.
     /// </summary>
     protected virtual bool UpdateInternal()
     {
       float newValue = UpdateSingleValue();
-      if (Mathf.Approximately(newValue, values[0]))
+      if (ApproximatelyEqual(newValue, values[0]))
       {
         return false;
       }

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectFloatIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectFloatIntegrator.cs
@@ -61,13 +61,14 @@ namespace Waterfall
         {
           var rend = r[i];
           float val = workingValues[i];
-          
-          if (rend.enabled && val < Settings.MinimumEffectIntensity)
-            rend.enabled = false;
-          else if (!rend.enabled && val >= Settings.MinimumEffectIntensity)
-            rend.enabled = true;
+          bool shouldBeVisible = val >= Settings.MinimumEffectIntensity;
 
-          if (rend.enabled)
+          if (rend.enabled != shouldBeVisible)
+          {
+            rend.enabled = shouldBeVisible;
+          }
+
+          if (shouldBeVisible)
           {
             rend.material.SetFloat(floatPropertyID, val);
             anyActive = true;

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectLightFloatIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectLightFloatIntegrator.cs
@@ -11,7 +11,7 @@ namespace Waterfall
 
     private readonly Light[]     l;
 
-    public EffectLightFloatIntegrator(WaterfallEffect effect, EffectLightFloatModifier floatMod) : base(effect, floatMod, WaterfallConstants.ShaderPropertyHideFloatNames.Contains(floatMod.floatName))
+    public EffectLightFloatIntegrator(WaterfallEffect effect, EffectLightFloatModifier floatMod) : base(effect, floatMod, floatMod.floatName == "Intensity")
     {
       // light-float specific
       floatName = floatMod.floatName;

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectLightFloatIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectLightFloatIntegrator.cs
@@ -39,10 +39,12 @@ namespace Waterfall
         float value = workingValues[i] * lightBaseScale;
         if (testIntensity)
         {
-          if (light.enabled && value < Settings.MinimumLightIntensity)
-            light.enabled = false;
-          else if (!light.enabled && value >= Settings.MinimumLightIntensity)
-            light.enabled = true;
+          bool shouldBeVisible = value >= Settings.MinimumLightIntensity;
+
+          if (light.enabled != shouldBeVisible)
+          {
+            light.enabled = shouldBeVisible;
+          }
         }
         if (light.enabled)
         {


### PR DESCRIPTION
-fix broken intensity test for lights
-more aggressive controller sleeping (atmosphere depth was still usually awake on the launchpad previously)
-fixed a bug caused by modifier caching that became more obvious when all the controllers were asleep pre-launch (engines get wrong atmo values until it changes)
-fixed a sleeping bug in the RCS controller (wouldn't wake up when RCS shut off)
-more efficient renderer/light enabling code