### PR TITLE
More sophisticated controller/effect/integrator sleeping

### DIFF
--- a/GameData/Waterfall/WaterfallSettings.cfg
+++ b/GameData/Waterfall/WaterfallSettings.cfg
@@ -35,5 +35,13 @@ WATERFALL_SETTINGS
 
   // If this is false, all additive-type shader will be forced to true additive (one:one) blend mode
   EnableLegacyBlendModes = false
+
+  // disables optimizations around controllers that aren't changing their value
+  // if something doesn't work when this is false (default) and does work when it's true, it's a bug in Waterfall
+  ForceAllControllersAwake = false
+
+  // whether randomness controllers should be considered to be awake
+  // setting this to false will improve performance but might make effects slightly less randomized
+  RandomControllersAwake = true
 }
 

--- a/Source/Waterfall/EffectControllers/RandomnessController.cs
+++ b/Source/Waterfall/EffectControllers/RandomnessController.cs
@@ -63,11 +63,8 @@ namespace Waterfall
 
     protected override bool UpdateInternal()
     {
-      // this isn't really correct; we should probably use the normal "changed" logic here - but the way things are currently set up, marking these as awake is really bad for performance
-      // I think randomness is currently kind of broken anyway, it needs another pass since it's kind of a special case in the fixed-function pipeline
-      // But if someone hooked a random controller directly up to a modifier then it wouldn't update properly.
       values[0] = noiseFunc();
-      return false;
+      return Settings.RandomControllersAwake;
     }
   }
 }

--- a/Source/Waterfall/EffectControllers/RemapController.cs
+++ b/Source/Waterfall/EffectControllers/RemapController.cs
@@ -39,7 +39,7 @@ namespace Waterfall
     private IEnumerator FindSourceDelayed()
     {
       yield return new WaitForEndOfFrame();
-      source = parentModule.AllControllersDict[sourceController];
+      source = parentModule.FindController(sourceController);
       values = new float[source.Get().Length];
     }
 

--- a/Source/Waterfall/EffectControllers/WaterfallController.cs
+++ b/Source/Waterfall/EffectControllers/WaterfallController.cs
@@ -60,11 +60,13 @@ namespace Waterfall
 
     public bool Update()
     {
-      awake = overridden;
-      
-      if (!overridden)
+      if (overridden)
       {
-        awake = UpdateInternal();
+        awake = true;
+      }
+      else
+      {
+        awake = UpdateInternal() || Settings.ForceAllControllersAwake;
       }
 
       return awake;

--- a/Source/Waterfall/EffectControllers/WaterfallController.cs
+++ b/Source/Waterfall/EffectControllers/WaterfallController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
 using Waterfall.EffectControllers;
 
@@ -19,6 +20,7 @@ namespace Waterfall
     public ModuleWaterfallFX ParentModule => parentModule;
 
     public bool awake;
+    public UInt64 mask = 0; // this should always equal (1 << parentModule.Controllers.IndexOf(this))
 
     public bool overridden
     {

--- a/Source/Waterfall/EffectModifiers/EffectModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectModifier.cs
@@ -41,7 +41,7 @@ namespace Waterfall
 
     public EffectIntegrator integrator;
     public WaterfallController Controller { get; private set; }
-    protected WaterfallController randomController;
+    internal WaterfallController randomController;
     public virtual bool ValidForIntegrator => true;
 
     public EffectModifier()

--- a/Source/Waterfall/EffectModifiers/EffectModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectModifier.cs
@@ -41,7 +41,7 @@ namespace Waterfall
 
     public EffectIntegrator integrator;
     public WaterfallController Controller { get; private set; }
-    internal WaterfallController randomController;
+    protected WaterfallController randomController;
     public virtual bool ValidForIntegrator => true;
 
     public EffectModifier()
@@ -171,6 +171,22 @@ namespace Waterfall
         return true;
       }
       return false;
+    }
+
+    internal UInt64 GetControllerMask()
+    {
+      UInt64 usedControllerMask = 0;
+      if (Controller != null)
+      {
+        usedControllerMask |= Controller.mask;
+      }
+
+      if (useRandomness && randomController != null)
+      {
+        usedControllerMask |= randomController.mask;
+      }
+
+      return usedControllerMask;
     }
   }
 

--- a/Source/Waterfall/EffectModifiers/EffectModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectModifier.cs
@@ -68,7 +68,7 @@ namespace Waterfall
     public virtual void Init(WaterfallEffect effect)
     {
       parentEffect = effect;
-      Controller = parentEffect.parentModule.AllControllersDict.TryGetValue(controllerName, out var controller) ? controller : null;
+      Controller = parentEffect.parentModule.FindController(controllerName);
       if (Controller == null)
       {
         Utils.LogWarning($"[EffectModifier]: Controller {controllerName} not found for modifier {fxName} in effect {effect.name} in module {effect.parentModule.moduleID}");
@@ -78,7 +78,7 @@ namespace Waterfall
         Controller.referencingModifierCount++;
       }
 
-      randomController = parentEffect.parentModule.AllControllersDict.TryGetValue(randomnessController, out controller) ? controller : null;
+      randomController = parentEffect.parentModule.FindController(randomnessController);
 
       if (randomController == null && useRandomness)
       {

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
@@ -19,7 +19,7 @@ namespace Waterfall
         handledModifiers.Add(mod);
         mod.Controller.referencingModifierCount++; // the original code also evaluated controllers from the integrator, so we need to account for that here
 
-        hasRandoms |= (mod.useRandomness && Settings.RandomControllersAwake);
+        hasRandoms |= mod.useRandomness;
         usedControllerMask |= mod.Controller.mask;
       }
     }
@@ -59,10 +59,11 @@ namespace Waterfall
     public void RefreshControllerMask()
     {
       usedControllerMask = 0;
+      hasRandoms = false;
       foreach (var modifier in handledModifiers)
       {
         usedControllerMask |= modifier.Controller.mask;
-        hasRandoms |= (modifier.useRandomness && Settings.RandomControllersAwake);
+        hasRandoms |= modifier.useRandomness;
       }
     }
 

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Unity.Profiling;
 using UnityEngine;
 
@@ -17,6 +18,9 @@ namespace Waterfall
       {
         handledModifiers.Add(mod);
         mod.Controller.referencingModifierCount++; // the original code also evaluated controllers from the integrator, so we need to account for that here
+
+        hasRandoms |= (mod.useRandomness && Settings.RandomControllersAwake);
+        usedControllerMask |= mod.Controller.mask;
       }
     }
     public void RemoveModifier(EffectModifier mod)
@@ -28,6 +32,8 @@ namespace Waterfall
       {
         Update();
       }
+
+      RefreshControllerMask();
     }
 
     public EffectIntegrator(WaterfallEffect effect, EffectModifier mod)
@@ -46,6 +52,24 @@ namespace Waterfall
       }
 
       AddModifier(mod);
+    }
+
+    protected bool hasRandoms = false;
+    UInt64 usedControllerMask = 0;
+    public void RefreshControllerMask()
+    {
+      usedControllerMask = 0;
+      foreach (var modifier in handledModifiers)
+      {
+        usedControllerMask |= modifier.Controller.mask;
+        hasRandoms |= (modifier.useRandomness && Settings.RandomControllersAwake);
+      }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool NeedsUpdate(UInt64 awakeControllerMask)
+    {
+      return hasRandoms || (usedControllerMask & awakeControllerMask) != 0;
     }
 
     // REVIEW: there are some problems here:
@@ -304,7 +328,7 @@ namespace Waterfall
 
     public override void Update()
     {
-      Update_TestIntensity();
+      Update_TestIntensity(out bool unused);
     }
     protected override void Apply()
     {
@@ -313,7 +337,7 @@ namespace Waterfall
 
     protected abstract bool Apply_TestIntensity();
 
-    public bool Update_TestIntensity()
+    public bool Update_TestIntensity(out bool becameActive)
     {
       s_Update.Begin();
 
@@ -334,16 +358,7 @@ namespace Waterfall
       s_Apply.Begin();
       bool active = Apply_TestIntensity();
 
-      // when an integrator becomes active, we need to force all modifiers for that transform to update because they may have cached an old controller value that has gone to sleep
-      // We could do this by storing extra state on the modifiers, but just marking all controllers as awake for a frame works too and is simpler
-      // This shouldn't happen very often, only during engine ignition etc.
-      if (testIntensity && active && !wasActive)
-      {
-        foreach (var controller in parentEffect.parentModule.Controllers)
-        {
-          controller.awake = true;
-        }
-      }
+      becameActive = testIntensity && active && !wasActive;
       wasActive = active;
 
       s_Apply.End();

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
@@ -20,7 +20,7 @@ namespace Waterfall
         mod.Controller.referencingModifierCount++; // the original code also evaluated controllers from the integrator, so we need to account for that here
 
         hasRandoms |= mod.useRandomness;
-        usedControllerMask |= mod.Controller.mask;
+        usedControllerMask |= mod.GetControllerMask();
       }
     }
     public void RemoveModifier(EffectModifier mod)
@@ -62,7 +62,7 @@ namespace Waterfall
       hasRandoms = false;
       foreach (var modifier in handledModifiers)
       {
-        usedControllerMask |= modifier.Controller.mask;
+        usedControllerMask |= modifier.GetControllerMask();
         hasRandoms |= modifier.useRandomness;
       }
     }

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
@@ -324,6 +324,8 @@ namespace Waterfall
       testIntensity = testIntensity_;
     }
 
+    internal bool WasActive => wasActive;
+
     protected static readonly ProfilerMarker s_Update = new ProfilerMarker("Waterfall.Integrator_Float.Update");
 
     public override void Update()

--- a/Source/Waterfall/Effects/WaterfallEffect.cs
+++ b/Source/Waterfall/Effects/WaterfallEffect.cs
@@ -311,20 +311,7 @@ namespace Waterfall
       else if (mod is EffectParticleMultiColorModifier) mod.CreateOrAttachToIntegrator(particleColorIntegrators);
       else if (mod is DirectModifier directMod) directModifiers.Add(directMod);
 
-      UpdateControllerMaskForMod(mod);
-    }
-
-    void UpdateControllerMaskForMod(EffectModifier mod)
-    {
-      if (mod.Controller != null)
-      {
-        usedControllerMask |= mod.Controller.mask;
-      }
-
-      if (mod.useRandomness && mod.randomnessController != null)
-      {
-        usedControllerMask |= mod.randomController.mask;
-      }
+      usedControllerMask |= mod.GetControllerMask();
     }
 
     void SortIntegrators()
@@ -545,7 +532,7 @@ namespace Waterfall
       usedControllerMask = 0;
       foreach (var modifier in fxModifiers)
       {
-        UpdateControllerMaskForMod(modifier);
+        usedControllerMask |= modifier.GetControllerMask();
       }
     }
 

--- a/Source/Waterfall/Modules/ModuleWaterfallFX.cs
+++ b/Source/Waterfall/Modules/ModuleWaterfallFX.cs
@@ -218,9 +218,10 @@ namespace Waterfall
 
         for (int i = 0; i < allControllers.Count; ++i)
         {
-          if (allControllers[i].Update())
+          var controller = allControllers[i];
+          if (controller.Update())
           {
-            awakeControllerMask |= (1ul << i);
+            awakeControllerMask |= controller.mask;
           }
         }
         luControllers.End();

--- a/Source/Waterfall/Settings.cs
+++ b/Source/Waterfall/Settings.cs
@@ -31,6 +31,7 @@ namespace Waterfall
     public static bool EnableLights = true;
     public static bool EnableDistortion = true;
     public static bool EnableLegacyBlendModes = false;
+    public static bool ForceAllControllersAwake = false;
 
     private static bool _loadedOnce = false;
     /// <summary>
@@ -68,6 +69,7 @@ namespace Waterfall
         settingsNode.TryGetValue("EnableLights", ref EnableLights);
         settingsNode.TryGetValue("EnableDistortion", ref EnableDistortion);
         settingsNode.TryGetValue("EnableLegacyBlendModes", ref EnableLegacyBlendModes);
+        settingsNode.TryGetValue(nameof(ForceAllControllersAwake), ref ForceAllControllersAwake);
       }
       else
       {

--- a/Source/Waterfall/Settings.cs
+++ b/Source/Waterfall/Settings.cs
@@ -32,6 +32,7 @@ namespace Waterfall
     public static bool EnableDistortion = true;
     public static bool EnableLegacyBlendModes = false;
     public static bool ForceAllControllersAwake = false;
+    public static bool RandomControllersAwake = true;
 
     private static bool _loadedOnce = false;
     /// <summary>
@@ -70,6 +71,7 @@ namespace Waterfall
         settingsNode.TryGetValue("EnableDistortion", ref EnableDistortion);
         settingsNode.TryGetValue("EnableLegacyBlendModes", ref EnableLegacyBlendModes);
         settingsNode.TryGetValue(nameof(ForceAllControllersAwake), ref ForceAllControllersAwake);
+        settingsNode.TryGetValue(nameof(RandomControllersAwake), ref RandomControllersAwake);
       }
       else
       {

--- a/Source/Waterfall/UI/ModifierWindows/UIModifierWindow.cs
+++ b/Source/Waterfall/UI/ModifierWindows/UIModifierWindow.cs
@@ -7,7 +7,7 @@ namespace Waterfall.UI
   {
     public UIModifierWindow(EffectModifier mod, bool show) : base(show)
     {
-      controllerNames = mod.parentEffect.parentModule.GetControllerNames().ToArray();
+      controllerNames = mod.parentEffect.parentModule.GetControllerNames();
       for (int i = 0; i < controllerNames.Length; i++)
       {
         if (controllerNames[i] == mod.controllerName)

--- a/Source/Waterfall/UI/UIModifierPopupWindow.cs
+++ b/Source/Waterfall/UI/UIModifierPopupWindow.cs
@@ -57,7 +57,7 @@ namespace Waterfall.UI
       showWindow      = true;
       effect          = fx;
       windowMode      = ModifierPopupMode.Add;
-      controllerTypes = fx.parentModule.GetControllerNames().ToArray();
+      controllerTypes = fx.parentModule.GetControllerNames();
 
       var xFormOptions = fx.GetModelTransforms()[0].GetComponentsInChildren<Transform>().ToList();
       modifierFlag     = 0;


### PR DESCRIPTION
-we can now calculate a mask of awake controllers, and only update those effects and integrators that consume awake controllers
-random controllers are now always awake (fixes #163 )
-add settings to force all controllers awake and to treat random controllers as sleeping for performance
