### PR TITLE
Refactor integrators and TestIntensity

### DIFF
--- a/Source/Waterfall/EffectModifiers/EffectColorModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectColorModifier.cs
@@ -23,6 +23,10 @@ namespace Waterfall
 
     public EffectColorModifier(ConfigNode node) : base(node) { }
 
+    public override string ToString()
+    {
+      return colorName + " : " + controllerName + " : " + effectMode;
+    }
     public override void Init(WaterfallEffect parentEffect)
     {
       base.Init(parentEffect);

--- a/Source/Waterfall/EffectModifiers/EffectFloatModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectFloatModifier.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace Waterfall
@@ -13,6 +14,8 @@ namespace Waterfall
     [Persistent] public string floatName = "";
     private Material[] m;
     public override bool ValidForIntegrator => !string.IsNullOrEmpty(floatName);
+    public override bool TestIntensity => WaterfallConstants.ShaderPropertyHideFloatNames.Contains(floatName);
+
 
     public EffectFloatModifier() : base()
     {

--- a/Source/Waterfall/EffectModifiers/EffectFloatModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectFloatModifier.cs
@@ -24,6 +24,11 @@ namespace Waterfall
 
     public EffectFloatModifier(ConfigNode node) : base(node) { }
 
+    public override string ToString()
+    {
+      return floatName + " : " + controllerName + " : " + effectMode;
+    }
+
     public override void Init(WaterfallEffect parentEffect)
     {
       base.Init(parentEffect);

--- a/Source/Waterfall/EffectModifiers/EffectLightColorModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectLightColorModifier.cs
@@ -13,7 +13,7 @@ namespace Waterfall
     [Persistent] public string colorName = "_Main";
 
     private Light[] l;
-    public override bool ValidForIntegrator => !string.IsNullOrEmpty(colorName);
+    public override bool ValidForIntegrator => !string.IsNullOrEmpty(colorName) && Settings.EnableLights;
 
     public EffectLightColorModifier() : base()
     {

--- a/Source/Waterfall/EffectModifiers/EffectLightFloatModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectLightFloatModifier.cs
@@ -13,7 +13,7 @@ namespace Waterfall
     [Persistent] public string floatName = "";
     
     private Light[] l;
-    public override bool ValidForIntegrator => !string.IsNullOrEmpty(floatName);
+    public override bool ValidForIntegrator => !string.IsNullOrEmpty(floatName) && Settings.EnableLights;
     public override bool TestIntensity => floatName == "Intensity";
 
     public EffectLightFloatModifier() : base()

--- a/Source/Waterfall/EffectModifiers/EffectLightFloatModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectLightFloatModifier.cs
@@ -14,6 +14,7 @@ namespace Waterfall
     
     private Light[] l;
     public override bool ValidForIntegrator => !string.IsNullOrEmpty(floatName);
+    public override bool TestIntensity => floatName == "Intensity";
 
     public EffectLightFloatModifier() : base()
     {

--- a/Source/Waterfall/EffectModifiers/EffectModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectModifier.cs
@@ -55,6 +55,11 @@ namespace Waterfall
       Load(node);
     }
 
+    public override string ToString()
+    {
+      return modifierTypeName + " : " + controllerName + " : " + effectMode;
+    }
+
     public virtual void Load(ConfigNode node)
     {
       ConfigNode.LoadObjectFromConfig(this, node);

--- a/Source/Waterfall/EffectModifiers/EffectModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectModifier.cs
@@ -191,15 +191,28 @@ namespace Waterfall
     }
   }
 
-  public abstract class EffectModifier_Color : EffectModifier
+  public abstract class EffectModifier_Typed<T> : EffectModifier
+  {
+    public EffectModifier_Typed() : base() { }
+    public EffectModifier_Typed(ConfigNode node) : base(node) { }
+
+		public override void Init(WaterfallEffect effect)
+		{
+			base.Init(effect);
+      output = new T[xforms.Count];
+      outputWithRandom = new T[xforms.Count];
+		}
+
+		protected T[] output;
+    protected T[] outputWithRandom;
+  }
+
+  public abstract class EffectModifier_Color : EffectModifier_Typed<Color>
   {
     public FastFloatCurve rCurve = new();
     public FastFloatCurve gCurve = new();
     public FastFloatCurve bCurve = new();
     public FastFloatCurve aCurve = new();
-
-    Color[] output;
-    Color[] outputWithRandom;
 
     public EffectModifier_Color() : base() { }
     public EffectModifier_Color(ConfigNode node) : base(node) { }
@@ -223,14 +236,6 @@ namespace Waterfall
       node.AddNode(Utils.SerializeFloatCurve("bCurve", bCurve));
       node.AddNode(Utils.SerializeFloatCurve("aCurve", aCurve));
       return node;
-    }
-
-    public override void Init(WaterfallEffect effect)
-    {
-      base.Init(effect);
-
-      output = new Color[xforms.Count];
-      outputWithRandom = new Color[xforms.Count];
     }
 
     public Color[] Get()
@@ -278,12 +283,10 @@ namespace Waterfall
     }
   }
 
-  public abstract class EffectModifier_Vector2 : EffectModifier
+  public abstract class EffectModifier_Vector2 : EffectModifier_Typed<Vector2>
   {
     public FastFloatCurve xCurve = new();
     public FastFloatCurve yCurve = new();
-    Vector2[] output;
-    Vector2[] outputWithRandom;
 
     public EffectModifier_Vector2() : base() { }
     public EffectModifier_Vector2(ConfigNode node) : base(node) { }
@@ -302,13 +305,6 @@ namespace Waterfall
       node.AddNode(Utils.SerializeFloatCurve("xCurve", xCurve));
       node.AddNode(Utils.SerializeFloatCurve("yCurve", yCurve));
       return node;
-    }
-
-    public override void Init(WaterfallEffect effect)
-    {
-      base.Init(effect);
-      output = new Vector2[xforms.Count];
-      outputWithRandom = new Vector2[xforms.Count];
     }
 
     public Vector2[] Get()
@@ -350,13 +346,11 @@ namespace Waterfall
       return output;
     }
   }
-  public abstract class EffectModifier_Vector3 : EffectModifier
+  public abstract class EffectModifier_Vector3 : EffectModifier_Typed<Vector3>
   {
     public FastFloatCurve xCurve = new();
     public FastFloatCurve yCurve = new();
     public FastFloatCurve zCurve = new();
-    Vector3[] output;
-    Vector3[] outputWithRandom;
 
     public EffectModifier_Vector3() : base() { }
     public EffectModifier_Vector3(ConfigNode node) : base(node) { }
@@ -377,13 +371,6 @@ namespace Waterfall
       node.AddNode(Utils.SerializeFloatCurve("yCurve", yCurve));
       node.AddNode(Utils.SerializeFloatCurve("zCurve", zCurve));
       return node;
-    }
-
-    public override void Init(WaterfallEffect effect)
-    {
-      base.Init(effect);
-      output = new Vector3[xforms.Count];
-      outputWithRandom = new Vector3[xforms.Count];
     }
 
     public Vector3[] Get()
@@ -430,11 +417,9 @@ namespace Waterfall
     }
   }
 
-  public abstract class EffectModifier_Float : EffectModifier
+  public abstract class EffectModifier_Float : EffectModifier_Typed<float>
   {
     public FastFloatCurve curve = new();
-    float[] output;
-    float[] outputWithRandom;
 
     public EffectModifier_Float() : base() { }
     public EffectModifier_Float(ConfigNode node) : base(node) { }
@@ -449,13 +434,6 @@ namespace Waterfall
       var node = base.Save();
       node.AddNode(Utils.SerializeFloatCurve("floatCurve", curve));
       return node;
-    }
-
-    public override void Init(WaterfallEffect effect)
-    {
-      base.Init(effect);
-      output = new float[xforms.Count];
-      outputWithRandom = new float[xforms.Count];
     }
 
     public float[] Get()

--- a/Source/Waterfall/EffectModifiers/EffectModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectModifier.cs
@@ -196,14 +196,14 @@ namespace Waterfall
     public EffectModifier_Typed() : base() { }
     public EffectModifier_Typed(ConfigNode node) : base(node) { }
 
-		public override void Init(WaterfallEffect effect)
-		{
-			base.Init(effect);
+    public override void Init(WaterfallEffect effect)
+    {
+      base.Init(effect);
       output = new T[xforms.Count];
       outputWithRandom = new T[xforms.Count];
-		}
+    }
 
-		protected T[] output;
+    protected T[] output;
     protected T[] outputWithRandom;
   }
 

--- a/Source/Waterfall/EffectModifiers/EffectModifier.cs
+++ b/Source/Waterfall/EffectModifiers/EffectModifier.cs
@@ -43,6 +43,7 @@ namespace Waterfall
     public WaterfallController Controller { get; private set; }
     protected WaterfallController randomController;
     public virtual bool ValidForIntegrator => true;
+    public virtual bool TestIntensity => false;
 
     public EffectModifier()
     {

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectFloatIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectFloatIntegrator.cs
@@ -25,7 +25,7 @@ namespace Waterfall
     private readonly Material[] materials;
     private float[] lastValues;
 
-    public EffectFloatIntegrator(WaterfallEffect effect, EffectFloatModifier floatMod) : base(effect, floatMod, WaterfallConstants.ShaderPropertyHideFloatNames.Contains(floatMod.floatName))
+    public EffectFloatIntegrator(WaterfallEffect effect, EffectFloatModifier floatMod) : base(effect, floatMod)
     {
       // float specific
       floatName = floatMod.floatName;

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectFloatIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectFloatIntegrator.cs
@@ -55,7 +55,7 @@ namespace Waterfall
       }
     }
 
-    protected override bool Apply_TestIntensity()
+    protected override void Apply()
     {
       bool anyActive;
 
@@ -99,7 +99,7 @@ namespace Waterfall
         }
       }
 
-      return anyActive;
+      active = anyActive;
     }
   }
 }

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
@@ -40,12 +40,12 @@ namespace Waterfall
       RefreshControllerMask();
     }
 
-    public EffectIntegrator(WaterfallEffect effect, EffectModifier mod, bool testIntensity = false)
+    public EffectIntegrator(WaterfallEffect effect, EffectModifier mod)
     {
       Utils.Log($"[EffectIntegrator]: Initializing integrator for {effect.name} on modifier {mod.fxName}", LogType.Modifiers);
       transformName = mod.transformName;
       parentEffect = effect;
-      this.testIntensity = testIntensity;
+      this.testIntensity = mod.TestIntensity;
 
       var roots = parentEffect.GetModelTransforms();
       foreach (var t in roots)
@@ -312,7 +312,7 @@ namespace Waterfall
     protected readonly T_Value[] initialValues;
     protected readonly T_Value[] workingValues;
 
-    public EffectIntegratorTyped(WaterfallEffect effect, EffectModifier mod, bool testIntensity = false) : base(effect, mod, testIntensity)
+    public EffectIntegratorTyped(WaterfallEffect effect, EffectModifier mod) : base(effect, mod)
     {
       initialValues = new T_Value[xforms.Count];
       workingValues = new T_Value[xforms.Count];
@@ -321,7 +321,7 @@ namespace Waterfall
 
   public abstract class EffectIntegrator_Float : EffectIntegratorTyped<float>
   {
-    public EffectIntegrator_Float(WaterfallEffect effect, EffectModifier_Float mod, bool testIntensity) : base(effect, mod, testIntensity) { }
+    public EffectIntegrator_Float(WaterfallEffect effect, EffectModifier_Float mod) : base(effect, mod) { }
 
     protected static readonly ProfilerMarker s_Update = new ProfilerMarker("Waterfall.Integrator_Float.Update");
 

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
@@ -78,8 +78,7 @@ namespace Waterfall
     // This might be overthinking it - it's only 2 virtual calls per integrator
     // Should the common part just be a protected function that the virtual derived classes have to call?
     // This might make profiling markup annoying
-    // B) it's a code smell that the bool return value is only meaningful for some of the integrators (float integrators that control visibility)
-    // C) It's strange that the boolean for TestIntensity lives in the EffectIntegrator_Float but the threshold and application logic is in the derived classes
+
     public abstract void Update();
     protected abstract void Apply();
 
@@ -318,29 +317,16 @@ namespace Waterfall
   public abstract class EffectIntegrator_Float : EffectIntegratorTyped<float>
   {
     public readonly bool testIntensity;
-    bool wasActive;
+    public bool active;
 
     public EffectIntegrator_Float(WaterfallEffect effect, EffectModifier_Float mod, bool testIntensity_) : base(effect, mod)
     {
       testIntensity = testIntensity_;
     }
 
-    internal bool WasActive => wasActive;
-
     protected static readonly ProfilerMarker s_Update = new ProfilerMarker("Waterfall.Integrator_Float.Update");
 
     public override void Update()
-    {
-      Update_TestIntensity(out bool unused);
-    }
-    protected override void Apply()
-    {
-      Apply_TestIntensity();
-    }
-
-    protected abstract bool Apply_TestIntensity();
-
-    public bool Update_TestIntensity(out bool becameActive)
     {
       s_Update.Begin();
 
@@ -359,16 +345,10 @@ namespace Waterfall
       s_Modifiers.End();
 
       s_Apply.Begin();
-      bool active = Apply_TestIntensity();
-
-      becameActive = testIntensity && active && !wasActive;
-      wasActive = active;
-
+      Apply();
       s_Apply.End();
 
       s_Update.End();
-
-      return active;
     }
   }
 

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
@@ -12,6 +12,10 @@ namespace Waterfall
     protected WaterfallEffect parentEffect;
     protected List<Transform> xforms = new();
     public List<EffectModifier> handledModifiers = new();
+
+    public readonly bool testIntensity;
+    public bool active = true;
+
     public void AddModifier(EffectModifier mod)
     {
       if (mod.Controller != null)
@@ -36,11 +40,12 @@ namespace Waterfall
       RefreshControllerMask();
     }
 
-    public EffectIntegrator(WaterfallEffect effect, EffectModifier mod)
+    public EffectIntegrator(WaterfallEffect effect, EffectModifier mod, bool testIntensity = false)
     {
       Utils.Log($"[EffectIntegrator]: Initializing integrator for {effect.name} on modifier {mod.fxName}", LogType.Modifiers);
       transformName = mod.transformName;
       parentEffect = effect;
+      this.testIntensity = testIntensity;
 
       var roots = parentEffect.GetModelTransforms();
       foreach (var t in roots)
@@ -307,7 +312,7 @@ namespace Waterfall
     protected readonly T_Value[] initialValues;
     protected readonly T_Value[] workingValues;
 
-    public EffectIntegratorTyped(WaterfallEffect effect, EffectModifier mod) : base(effect, mod)
+    public EffectIntegratorTyped(WaterfallEffect effect, EffectModifier mod, bool testIntensity = false) : base(effect, mod, testIntensity)
     {
       initialValues = new T_Value[xforms.Count];
       workingValues = new T_Value[xforms.Count];
@@ -316,13 +321,7 @@ namespace Waterfall
 
   public abstract class EffectIntegrator_Float : EffectIntegratorTyped<float>
   {
-    public readonly bool testIntensity;
-    public bool active;
-
-    public EffectIntegrator_Float(WaterfallEffect effect, EffectModifier_Float mod, bool testIntensity_) : base(effect, mod)
-    {
-      testIntensity = testIntensity_;
-    }
+    public EffectIntegrator_Float(WaterfallEffect effect, EffectModifier_Float mod, bool testIntensity) : base(effect, mod, testIntensity) { }
 
     protected static readonly ProfilerMarker s_Update = new ProfilerMarker("Waterfall.Integrator_Float.Update");
 

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectIntegrator.cs
@@ -334,9 +334,11 @@ namespace Waterfall
       s_ListPrep.End();
 
       s_Modifiers.Begin();
-      foreach (var mod in handledModifiers)
+      int modifierCount = handledModifiers.Count;
+      for (int i = 0; i < modifierCount; i++)
       {
-        float[] modifierData = ((EffectModifier_Float)mod).Get();
+        var mod = (EffectModifier_Float)handledModifiers[i];
+        float[] modifierData = mod.Get();
         s_Integrate.Begin();
         Integrate(mod.effectMode, workingValues, modifierData);
         s_Integrate.End();
@@ -366,9 +368,11 @@ namespace Waterfall
       s_ListPrep.End();
 
       s_Modifiers.Begin();
-      foreach (var mod in handledModifiers)
+      int modifierCount = handledModifiers.Count;
+      for (int i = 0; i < modifierCount; i++)
       {
-        Color[] modifierData = ((EffectModifier_Color)mod).Get();
+        var mod = (EffectModifier_Color)handledModifiers[i];
+        Color[] modifierData = mod.Get();
         s_Integrate.Begin();
         Integrate(mod.effectMode, workingValues, modifierData);
         s_Integrate.End();
@@ -397,9 +401,11 @@ namespace Waterfall
       s_ListPrep.End();
 
       s_Modifiers.Begin();
-      foreach (var mod in handledModifiers)
+      int modifierCount = handledModifiers.Count;
+      for (int i = 0; i < modifierCount; i++)
       {
-        Vector2[] modifierData = ((EffectModifier_Vector2)mod).Get();
+        var mod = (EffectModifier_Vector2)handledModifiers[i];
+        Vector2[] modifierData = mod.Get();
         s_Integrate.Begin();
         Integrate(mod.effectMode, workingValues, modifierData);
         s_Integrate.End();        
@@ -429,9 +435,11 @@ namespace Waterfall
       s_ListPrep.End();
 
       s_Modifiers.Begin();
-      foreach (var mod in handledModifiers)
+      int modifierCount = handledModifiers.Count;
+      for (int i = 0; i < modifierCount; i++)
       {
-        Vector3[] modifierData = ((EffectModifier_Vector3)mod).Get();
+        var mod = (EffectModifier_Vector3)handledModifiers[i];
+        Vector3[] modifierData = mod.Get();
         s_Integrate.Begin();
         Integrate(mod.effectMode, workingValues, modifierData);
         s_Integrate.End();

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectLightFloatIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectLightFloatIntegrator.cs
@@ -11,7 +11,7 @@ namespace Waterfall
 
     private readonly Light[]     l;
 
-    public EffectLightFloatIntegrator(WaterfallEffect effect, EffectLightFloatModifier floatMod) : base(effect, floatMod, floatMod.floatName == "Intensity")
+    public EffectLightFloatIntegrator(WaterfallEffect effect, EffectLightFloatModifier floatMod) : base(effect, floatMod)
     {
       // light-float specific
       floatName = floatMod.floatName;

--- a/Source/Waterfall/Effects/EffectIntegrators/EffectLightFloatIntegrator.cs
+++ b/Source/Waterfall/Effects/EffectIntegrators/EffectLightFloatIntegrator.cs
@@ -28,7 +28,7 @@ namespace Waterfall
       }
     }
 
-    protected override bool Apply_TestIntensity()
+    protected override void Apply()
     {
       bool anyActive = false;
 
@@ -53,7 +53,7 @@ namespace Waterfall
         }
       }
 
-      return anyActive;
+      active = anyActive;
     }
 
     protected void UpdateFloats(Light l, float f)

--- a/Source/Waterfall/Effects/WaterfallEffect.cs
+++ b/Source/Waterfall/Effects/WaterfallEffect.cs
@@ -340,26 +340,23 @@ namespace Waterfall
 
     private void UpdateIntegratorArray<T>(List<T> integrators, UInt64 awakeControllerMask) where T : EffectIntegrator
     {
-      for (int i = 0; i < integrators.Count;)
+      for (int i = integrators.Count-1; i >= 0;)
       {
         var integrator = integrators[i];
 
+        // skip the block of integrators with the same transform name
         if (disabledTransformNames.Contains(integrator.transformName))
         {
           // TODO: we could build a table that would let us jump to the next one immediately instead of looping
           string transformName = integrator.transformName;
-          ++i;
-          while (i < integrators.Count && integrators[i].transformName == transformName)
-          {
-            ++i;
-          }
+          while (i-- > 0 && integrators[i].transformName == transformName) ;
           continue;
         }
         else if (integrator.NeedsUpdate(awakeControllerMask))
         {
           integrator.Update();
         }
-        ++i;
+        --i;
       }
     }
 
@@ -367,7 +364,7 @@ namespace Waterfall
     {
       bool anyActive = false;
 
-      for (int i=0; i < integrators.Count;)
+      for (int i = integrators.Count; i-- > 0;)
       {
         var integrator = integrators[i];
 
@@ -396,21 +393,9 @@ namespace Waterfall
         // if this integrator controls the visibility for a specific transform and it's turned off, we can skip the remaining integrators on this transform
         else
         {
-          // TODO: we could build a table that would let us jump to the next one immediately instead of looping
           string transformName = integrator.transformName;
           disabledTransformNames.Add(transformName);
-
-          // This loop may be useless if only one integrator is typically controlling the visibility of a given transform
-          ++i;
-          while (i < integrators.Count && integrators[i].transformName == transformName)
-          {
-            ++i;
-          }
-
-          continue;
         }
-        
-        ++i;
       }
 
       return anyActive;

--- a/Source/Waterfall/Effects/WaterfallEffect.cs
+++ b/Source/Waterfall/Effects/WaterfallEffect.cs
@@ -406,21 +406,16 @@ namespace Waterfall
       {
         var integrator = integrators[i];
 
-        bool becameActive, rendererActive;
+        bool wasActive = integrator.active;
         if (integrator.NeedsUpdate(awakeControllerMask))
         {
-          rendererActive = integrator.Update_TestIntensity(out becameActive);
-        }
-        else
-        {
-          rendererActive = integrator.WasActive;
-          becameActive = false;
+          integrator.Update();
         }
         
-        if (rendererActive)
+        if (integrator.active)
         {
           anyActive = true;
-          if (becameActive)
+          if (!wasActive && integrator.testIntensity)
           {
             // when an integrator becomes active, we need to force all modifiers for that transform to update because they may have cached an old controller value that has gone to sleep
             // We could do this by storing extra state on the modifiers, but just marking all controllers as awake for a frame works too and is simpler
@@ -434,7 +429,7 @@ namespace Waterfall
           }
         }
         // if this integrator controls the visibility for a specific transform and it's turned off, we can skip the remaining integrators on this transform
-        // NOTE: Integrator.Update_TestIntensity only ever returns false if testIntensity is true, so no need to check it again here
+        // NOTE: Integrator.active only ever becomes false if testIntensity is true, so no need to check it again here
         else
         {
           // TODO: we could build a table that would let us jump to the next one immediately instead of looping

--- a/Source/Waterfall/Effects/WaterfallEffect.cs
+++ b/Source/Waterfall/Effects/WaterfallEffect.cs
@@ -78,6 +78,11 @@ namespace Waterfall
       Load(fx.Save());
     }
 
+    public override string ToString()
+    {
+      return name + ":" + parentName;
+    }
+
     public Vector3 TemplatePositionOffset { get; set; }
     public Vector3 TemplateRotationOffset { get; set; }
     public Vector3 TemplateScaleOffset    { get; set; }


### PR DESCRIPTION
-pushed testIntensity to the base integrator class
-can now get rid of bespoke update/apply functions on the float integrator
-no longer need to separate integrators by value type, just testIntensity/direct/other
-simpler integrator sorting logic (only needs to be grouped by transform)